### PR TITLE
Revert NotificacionImprimir report to embedded resource

### DIFF
--- a/Apex/Apex.vbproj
+++ b/Apex/Apex.vbproj
@@ -807,9 +807,9 @@
     <EmbeddedResource Include="Reportes\DesignacionImprimir.rdlc">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </EmbeddedResource>
-    <Content Include="Reportes\NotificacionImprimir.rdlc">
+    <EmbeddedResource Include="Reportes\NotificacionImprimir.rdlc">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    </EmbeddedResource>
     <EmbeddedResource Include="Reportes\ReporteNovedades_Fotos.rdlc">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </EmbeddedResource>


### PR DESCRIPTION
## Summary
- revert the reapplication of copying NotificacionImprimir.rdlc as content
- restore the report to be treated as an embedded resource with copy to output directory

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d370ca483883268f0f19cbb082b3cf