### PR TITLE
Add date selector for vigent license filter

### DIFF
--- a/Apex/Services/LicenciaService.vb
+++ b/Apex/Services/LicenciaService.vb
@@ -287,14 +287,15 @@ Public Class LicenciaService
     ''' Este método ahora es mucho más rápido porque depende del GetAllConDetallesAsync refactorizado.
     ''' </summary>
     Public Async Function GetVigentesHoyAsync(
-    Optional filtroNombre As String = "",
-    Optional tiposLicenciaIds As List(Of Integer) = Nothing,
-    Optional soloActivos As Boolean? = True
-) As Task(Of List(Of LicenciaConFuncionarioExtendidoDto))
-        Dim hoy As Date = Date.Today
+        Optional filtroNombre As String = "",
+        Optional tiposLicenciaIds As List(Of Integer) = Nothing,
+        Optional soloActivos As Boolean? = True,
+        Optional fechaReferencia As Date? = Nothing
+    ) As Task(Of List(Of LicenciaConFuncionarioExtendidoDto))
+        Dim fechaConsulta As Date = If(fechaReferencia.HasValue, fechaReferencia.Value.Date, Date.Today)
 
         Using uow As New UnitOfWork()
-            Dim query = uow.Repository(Of HistoricoLicencia)().GetAll().AsNoTracking().Where(Function(l) l.inicio <= hoy AndAlso l.finaliza >= hoy)
+            Dim query = uow.Repository(Of HistoricoLicencia)().GetAll().AsNoTracking().Where(Function(l) l.inicio <= fechaConsulta AndAlso l.finaliza >= fechaConsulta)
 
             If Not String.IsNullOrWhiteSpace(filtroNombre) Then
                 query = query.Where(Function(h) h.Funcionario.Nombre.Contains(filtroNombre) OrElse h.Funcionario.CI.Contains(filtroNombre))

--- a/Apex/UI/frmLicencias.Designer.vb
+++ b/Apex/UI/frmLicencias.Designer.vb
@@ -24,6 +24,8 @@ Partial Class frmLicencias
         Me.btnEditarLicencia = New System.Windows.Forms.Button()
         Me.btnNuevaLicencia = New System.Windows.Forms.Button()
         Me.PanelBusquedaLicencias = New System.Windows.Forms.Panel()
+        Me.dtpFechaVigencia = New System.Windows.Forms.DateTimePicker()
+        Me.lblFechaVigencia = New System.Windows.Forms.Label()
         Me.chkSoloVigentes = New System.Windows.Forms.CheckBox()
         Me.txtBusquedaLicencia = New System.Windows.Forms.TextBox()
         Me.Label1 = New System.Windows.Forms.Label()
@@ -96,6 +98,8 @@ Partial Class frmLicencias
         '
         'PanelBusquedaLicencias
         '
+        Me.PanelBusquedaLicencias.Controls.Add(Me.dtpFechaVigencia)
+        Me.PanelBusquedaLicencias.Controls.Add(Me.lblFechaVigencia)
         Me.PanelBusquedaLicencias.Controls.Add(Me.chkSoloVigentes)
         Me.PanelBusquedaLicencias.Controls.Add(Me.txtBusquedaLicencia)
         Me.PanelBusquedaLicencias.Controls.Add(Me.Label1)
@@ -111,10 +115,29 @@ Partial Class frmLicencias
         Me.chkSoloVigentes.AutoSize = True
         Me.chkSoloVigentes.Location = New System.Drawing.Point(517, 16)
         Me.chkSoloVigentes.Name = "chkSoloVigentes"
-        Me.chkSoloVigentes.Size = New System.Drawing.Size(159, 24)
+        Me.chkSoloVigentes.Size = New System.Drawing.Size(133, 24)
         Me.chkSoloVigentes.TabIndex = 2
-        Me.chkSoloVigentes.Text = "Sólo vigentes hoy"
+        Me.chkSoloVigentes.Text = "Sólo vigentes"
         Me.chkSoloVigentes.UseVisualStyleBackColor = True
+        '
+        'lblFechaVigencia
+        '
+        Me.lblFechaVigencia.AutoSize = True
+        Me.lblFechaVigencia.Location = New System.Drawing.Point(656, 18)
+        Me.lblFechaVigencia.Name = "lblFechaVigencia"
+        Me.lblFechaVigencia.Size = New System.Drawing.Size(55, 20)
+        Me.lblFechaVigencia.TabIndex = 3
+        Me.lblFechaVigencia.Text = "Fecha:"
+        '
+        'dtpFechaVigencia
+        '
+        Me.dtpFechaVigencia.Enabled = False
+        Me.dtpFechaVigencia.Format = System.Windows.Forms.DateTimePickerFormat.[Short]
+        Me.dtpFechaVigencia.Location = New System.Drawing.Point(717, 14)
+        Me.dtpFechaVigencia.Margin = New System.Windows.Forms.Padding(3, 4, 3, 4)
+        Me.dtpFechaVigencia.Name = "dtpFechaVigencia"
+        Me.dtpFechaVigencia.Size = New System.Drawing.Size(135, 26)
+        Me.dtpFechaVigencia.TabIndex = 4
         '
         'txtBusquedaLicencia
         '
@@ -163,4 +186,6 @@ Partial Class frmLicencias
     Friend WithEvents txtBusquedaLicencia As TextBox
     Friend WithEvents Label1 As Label
     Friend WithEvents chkSoloVigentes As CheckBox
+    Friend WithEvents lblFechaVigencia As Label
+    Friend WithEvents dtpFechaVigencia As DateTimePicker
 End Class

--- a/Apex/UI/frmLicencias.vb
+++ b/Apex/UI/frmLicencias.vb
@@ -33,8 +33,9 @@ Public Class frmLicencias
         txtBusquedaLicencia.Focus()
         AddHandler NotificadorEventos.FuncionarioActualizado, AddressOf OnFuncionarioActualizado
 
+        dtpFechaVigencia.Value = Date.Today
         chkSoloVigentes.Checked = True
-        _isFirstLoad = False
+        dtpFechaVigencia.Enabled = chkSoloVigentes.Checked
 
         Try
             AppTheme.SetCue(txtBusquedaLicencia, "Buscar por funcionario…")
@@ -44,6 +45,7 @@ Public Class frmLicencias
         ' --- PRIMERA CARGA CON TOKEN ---
         Dim tk = ReiniciarToken()
         Await CargarDatosLicenciasAsync(tk)
+        _isFirstLoad = False
     End Sub
 
     Private Sub frmGestionLicencias_FormClosed(sender As Object, e As FormClosedEventArgs) Handles Me.FormClosed
@@ -172,7 +174,8 @@ Public Class frmLicencias
 
             Dim datos As List(Of LicenciaConFuncionarioExtendidoDto)
             If soloVigentes Then
-                datos = Await _licenciaSvc.GetVigentesHoyAsync(filtroNombre:=filtro).WaitAsync(token)
+                Dim fechaVigencia = If(dtpFechaVigencia IsNot Nothing, dtpFechaVigencia.Value.Date, Date.Today)
+                datos = Await _licenciaSvc.GetVigentesHoyAsync(filtroNombre:=filtro, fechaReferencia:=fechaVigencia).WaitAsync(token)
             Else
                 datos = Await _licenciaSvc.GetAllConDetallesAsync(filtroNombre:=filtro).WaitAsync(token)
             End If
@@ -299,6 +302,13 @@ Public Class frmLicencias
 
     Private Async Sub chkSoloVigentes_CheckedChanged(sender As Object, e As EventArgs) Handles chkSoloVigentes.CheckedChanged
         If _isFirstLoad Then Return
+        dtpFechaVigencia.Enabled = chkSoloVigentes.Checked
+        Dim tk = ReiniciarToken()
+        Await CargarDatosLicenciasAsync(tk)
+    End Sub
+
+    Private Async Sub dtpFechaVigencia_ValueChanged(sender As Object, e As EventArgs) Handles dtpFechaVigencia.ValueChanged
+        If _isFirstLoad OrElse Not chkSoloVigentes.Checked Then Return
         Dim tk = ReiniciarToken()
         Await CargarDatosLicenciasAsync(tk)
     End Sub


### PR DESCRIPTION
## Summary
- allow passing a reference date to `LicenciaService.GetVigentesHoyAsync`
- add a date selector to the licenses screen to choose the day used when filtering vigent records
- reload data when the vigent checkbox or selected date changes

## Testing
- not run (Windows Forms app targeting .NET Framework 4.8)


------
https://chatgpt.com/codex/tasks/task_e_68d4485db2dc83268c8048eb5db5a027