### PR TITLE
Fix navigation after editing transient state

### DIFF
--- a/Apex/UI/frmFuncionarioCrear.vb
+++ b/Apex/UI/frmFuncionarioCrear.vb
@@ -839,7 +839,6 @@ Public Class frmFuncionarioCrear
         Dim frm As New frmFuncionarioEstadoTransitorio(row.EntityRef, _tiposEstadoTransitorio, _uow)
 
         AddHandler frm.EstadoConfigurado, Sub(estadoModificado As EstadoTransitorio)
-                                              ' Esto ya está correcto
                                               UpdateRowFromEntity(row, estadoModificado)
                                               bsEstados.ResetBindings(False)
 
@@ -849,8 +848,6 @@ Public Class frmFuncionarioCrear
                                                       cboCargo.SelectedValue = detalle.CargoNuevoId
                                                   End If
                                               End If
-
-                                              AbrirChildEnDashboard(frm)
                                           End Sub
 
         AbrirChildEnDashboard(frm)


### PR DESCRIPTION
## Summary
- stop reopening the transient state editor inside its EstadoConfigurado handler so navigation returns to the previous form cleanly

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d4c6c60e94832695ffca5f091ec802