### PR TITLE
Abrir dotaciones en el dashboard

### DIFF
--- a/Apex/UI/frmFuncionarioDotacion.vb
+++ b/Apex/UI/frmFuncionarioDotacion.vb
@@ -1,6 +1,8 @@
 ﻿' Apex/UI/frmFuncionarioDotacion.vb
 Public Class frmFuncionarioDotacion
 
+    Public Event DotacionConfigurada(dotacion As FuncionarioDotacion)
+
     Public Dotacion As FuncionarioDotacion
     Private _svc As New FuncionarioService()
 
@@ -66,6 +68,7 @@ Public Class frmFuncionarioDotacion
             ' Éxito (mostrar antes de cerrar)
             Notifier.Success(Me, "Dotación guardada correctamente.")
             DialogResult = DialogResult.OK
+            RaiseEvent DotacionConfigurada(Dotacion)
             Close()
 
         Catch ex As Exception


### PR DESCRIPTION
## Summary
- agrega un evento de notificación en `frmFuncionarioDotacion` para informar al formulario padre cuando se guarda una dotación
- actualiza `frmFuncionarioCrear` para abrir los formularios de dotación dentro del dashboard y manejar el guardado mediante el nuevo evento

## Testing
- `dotnet build Apex.sln` *(falla: el comando `dotnet` no está disponible en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d3d13db88326ac7e4089da40985b