### PR TITLE
Handle missing quantities subtitle

### DIFF
--- a/Apex/UI/frmVisorReporte.vb
+++ b/Apex/UI/frmVisorReporte.vb
@@ -175,16 +175,21 @@ Public Class frmVisorReporte
     End Function
 
     Private Shared Function ObtenerSubtituloCantidades(cantidadesDisponibles As String) As String
+        Const subtituloPredeterminado As String = "Cantidades no disponibles"
+
         If String.IsNullOrWhiteSpace(cantidadesDisponibles) Then
-            Return String.Empty
+            Return subtituloPredeterminado
         End If
 
         Dim lineas = cantidadesDisponibles.Split(New String() {Environment.NewLine}, StringSplitOptions.RemoveEmptyEntries)
-        If lineas.Length = 0 Then
-            Return String.Empty
-        End If
+        For Each linea In lineas
+            Dim lineaLimpia = linea.Trim()
+            If Not String.IsNullOrEmpty(lineaLimpia) Then
+                Return lineaLimpia
+            End If
+        Next
 
-        Return lineas(0).Trim()
+        Return subtituloPredeterminado
     End Function
 
 End Class


### PR DESCRIPTION
## Summary
- provide a default subtitle when the available quantities string is empty or whitespace
- ignore empty lines when selecting the subtitle from the provided quantities

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d656fbe03c8326bc4822c77bcb4e9a