### PR TITLE
Normalize notificacion data for filtros report

### DIFF
--- a/Apex/Helpers/ConsultasGenericas.vb
+++ b/Apex/Helpers/ConsultasGenericas.vb
@@ -113,8 +113,29 @@ Public Module ConsultasGenericas
                         Throw New ArgumentNullException("Las fechas de inicio y fin son requeridas para Notificaciones.")
                     End If
                     Dim notificacionService = New NotificacionService(uow)
-                    Dim notificaciones = Await notificacionService.GetAllConDetallesAsync()
-                    dt = notificaciones.Where(Function(n) n.FechaProgramada.Date >= fechaInicio.Value AndAlso n.FechaProgramada.Date <= fechaFin.Value).ToList().ToDataTable()
+                    Dim notificaciones = Await notificacionService.GetAllConDetallesAsync(
+                        fechaDesde:=fechaInicio,
+                        fechaHasta:=fechaFin
+                    )
+
+                    If Not notificaciones.Any() Then
+                        Return CrearTablaNotificacionesVacia()
+                    End If
+
+                    Dim resultadoNotificaciones = notificaciones.Select(Function(n) New With {
+                        .NombreCompleto = n.NombreFuncionario,
+                        .Cedula = n.CI,
+                        .TipoNotificacion = n.TipoNotificacion,
+                        .Estado = n.Estado,
+                        .FechaProgramada = n.FechaProgramada,
+                        .Texto = n.Texto,
+                        .Documento = n.Documento,
+                        .ExpMinisterial = n.ExpMinisterial,
+                        .ExpINR = n.ExpINR,
+                        .Oficina = n.Oficina
+                    }).ToList()
+
+                    dt = resultadoNotificaciones.ToDataTable()
                 Case TipoOrigenDatos.Licencias
                     Dim licenciaService = New LicenciaService(uow)
                     Dim licencias = Await licenciaService.GetAllConDetallesAsync(fechaDesde:=fechaInicio, fechaHasta:=fechaFin)
@@ -126,39 +147,26 @@ Public Module ConsultasGenericas
 
                     ' --- INICIO DE LA MODIFICACIÓN ---
 
-                    ' 1. Obtenemos una lista de todos los IDs de funcionario únicos de las licencias.
-                    Dim funcionarioIds = licencias.Select(Function(l) l.FuncionarioId).Distinct().ToList()
+                    ' Proyectamos los datos de las licencias usando la información ya enriquecida
+                    ' que devuelve el procedimiento almacenado. De esta manera evitamos incluir
+                    ' objetos complejos (entidades de EF) en el resultado, lo que generaba que
+                    ' en pantalla se mostraran los nombres de tipo (por ejemplo "Data_Entity…").
+                    Dim resultadoEnriquecido = licencias.Select(Function(lic) New With {
+                        .NombreCompleto = lic.NombreFuncionario,
+                        .Cedula = lic.CI,
+                        .TipoLicencia = lic.TipoLicencia,
+                        .FechaInicio = lic.FechaInicio,
+                        .FechaFin = lic.FechaFin,
+                        .Dias = lic.DuracionDias,
+                        .Observaciones = lic.Observaciones,
+                        .Activo = lic.Activo,
+                        .TipoDeFuncionario = lic.TipoDeFuncionario,
+                        .Cargo = lic.Cargo,
+                        .Seccion = lic.Seccion,
+                        .Escalafon = lic.Escalafon
+                    }).ToList()
 
-                    ' 2. Hacemos UNA SOLA consulta a la base de datos para traer todos los funcionarios necesarios.
-                    Dim funcionarios = Await uow.Repository(Of Funcionario)().
-                        GetAllByPredicateAsync(Function(f) funcionarioIds.Contains(f.Id))
-
-                    ' 3. Creamos un diccionario para buscar funcionarios por su ID de forma ultra-rápida.
-                    Dim funcionariosMap = funcionarios.ToDictionary(Function(f) f.Id)
-
-                    ' 4. Proyectamos los datos de las licencias a un nuevo objeto que SÍ incluye Nombre y Cédula.
-                    Dim resultadoEnriquecido = licencias.Select(Function(lic)
-                                                                    Dim func As Funcionario = Nothing
-                                                                    ' Buscamos el funcionario en nuestro mapa.
-                                                                    funcionariosMap.TryGetValue(lic.FuncionarioId, func)
-
-                                                                    Return New With {
-                                                        .NombreCompleto = func.Nombre,
-                                                        .Cedula = func.CI,
-                                                        .TipoLicencia = lic.TipoLicencia,
-                                                        .FechaInicio = lic.FechaInicio,
-                                                        .FechaFin = lic.FechaFin,
-                                                        .Dias = lic.DuracionDias,
-                                                        .Observaciones = lic.Observaciones,
-                                                        .Activo = func.Activo,
-                                                        .TipoDeFuncionario = func.TipoFuncionario,
-                                                        .Cargo = func.Cargo,
-                                                        .Seccion = func.Seccion,
-                                                        .Escalafon = func.Escalafon
-                                                    }
-                                                                End Function).ToList()
-
-                    ' 5. Convertimos la lista ENRIQUECIDA a un DataTable.
+                    ' Convertimos la lista enriquecida a un DataTable.
                     dt = resultadoEnriquecido.ToDataTable()
 
     ' --- FIN DE LA MODIFICACIÓN ---
@@ -520,5 +528,22 @@ Public Module ConsultasGenericas
 
         ' Construye el DataTable con todas las columnas (FuncionarioId, Cedula, NombreCompleto, Tipo, Anio, Mes, Fecha, Minutos, Dias, Incidencia, Observaciones, Motivo, Area)
         Return ModuloExtensions.ToDataTable(datos)
+    End Function
+
+    Private Function CrearTablaNotificacionesVacia() As DataTable
+        Dim table As New DataTable()
+
+        table.Columns.Add("NombreCompleto", GetType(String))
+        table.Columns.Add("Cedula", GetType(String))
+        table.Columns.Add("TipoNotificacion", GetType(String))
+        table.Columns.Add("Estado", GetType(String))
+        table.Columns.Add("FechaProgramada", GetType(Date))
+        table.Columns.Add("Texto", GetType(String))
+        table.Columns.Add("Documento", GetType(String))
+        table.Columns.Add("ExpMinisterial", GetType(String))
+        table.Columns.Add("ExpINR", GetType(String))
+        table.Columns.Add("Oficina", GetType(String))
+
+        Return table
     End Function
 End Module


### PR DESCRIPTION
## Summary
- filter the notificaciones query by the selected date range and project the view data into plain DTO-like fields so the filtros report shows user-friendly values
- return an empty notificacion schema when no records match to keep the report grid consistent

## Testing
- not run (windows-only project)


------
https://chatgpt.com/codex/tasks/task_e_68d81325aac4832680fdcf389c32dd8c