### PR TITLE
Seed Rol entries for usuario migration

### DIFF
--- a/CompleteMigration.sql
+++ b/CompleteMigration.sql
@@ -132,6 +132,7 @@ BEGIN
         DELETE FROM [dbo].[FuncionarioSalud];
         DELETE FROM [dbo].[NotificacionPersonal];
         DELETE FROM [dbo].[EstadoTransitorio];
+        DELETE FROM [dbo].[UsuarioRol];
         DELETE FROM [dbo].[Usuario];
         DELETE FROM [dbo].[MapPoliciaFunc];
 
@@ -204,6 +205,20 @@ BEGIN TRY
     SET IDENTITY_INSERT dbo.TipoFuncionario ON;
     MERGE INTO dbo.TipoFuncionario AS T USING (VALUES (1, 'Policia'), (2, 'Operador Penitenciario'), (3, 'Profesional Universitario'),(4, 'Técnico'), (5, 'Administrativo')) AS S (Id, Nombre) ON T.Id = S.Id WHEN NOT MATCHED THEN INSERT (Id, Nombre, CreatedAt) VALUES (S.Id, S.Nombre, GETDATE());
     SET IDENTITY_INSERT dbo.TipoFuncionario OFF;
+
+    SET IDENTITY_INSERT dbo.Rol ON;
+    MERGE dbo.Rol AS T
+    USING (VALUES
+        (1, 'Admin', 'Administrador del sistema'),
+        (2, 'Usuario', 'Usuario estándar')
+    ) AS S(Id, Nombre, Descripcion)
+        ON T.Id = S.Id
+    WHEN MATCHED THEN
+        UPDATE SET Nombre = S.Nombre, Descripcion = S.Descripcion
+    WHEN NOT MATCHED THEN
+        INSERT (Id, Nombre, Descripcion)
+        VALUES (S.Id, S.Nombre, S.Descripcion);
+    SET IDENTITY_INSERT dbo.Rol OFF;
 
     MERGE dbo.RolUsuario AS T USING (VALUES (1,'Admin',1), (2,'Usuario',2)) AS S(Id,Nombre,Orden) ON T.Id = S.Id WHEN NOT MATCHED THEN INSERT (Id,Nombre,Orden) VALUES (S.Id,S.Nombre,S.Orden);
 
@@ -336,7 +351,52 @@ BEGIN TRY
     ;WITH VA AS (SELECT hv.id_policia,hv.año,hv.mes,MIN(hv.incidencia) AS incidencia,MIN(hv.motivo) AS motivo FROM Personal.dbo.tblHistoricoViaticos hv GROUP BY hv.id_policia,hv.año,hv.mes) INSERT INTO dbo.HistoricoViatico (FuncionarioId,Anio,Mes,Incidencia,Motivo) SELECT m.FuncionarioId,va.año,va.mes,va.incidencia,va.motivo FROM VA va JOIN dbo.MapPoliciaFunc m ON m.id_policia = va.id_policia WHERE NOT EXISTS (SELECT 1 FROM dbo.HistoricoViatico hv WHERE hv.FuncionarioId = m.FuncionarioId AND hv.Anio = va.año AND hv.Mes = va.mes);
 
     -- Usuarios
-    ;WITH S AS (SELECT u.id_usuario, LOWER(LTRIM(RTRIM(u.usuario))) COLLATE DATABASE_DEFAULT AS UserName, HASHBYTES('SHA2_256',CAST(u.clave AS NVARCHAR(4000))) AS PwdHash, mp.FuncionarioId FROM Personal.dbo.tblUsuarios u LEFT JOIN dbo.MapPoliciaFunc mp ON mp.id_policia = u.id_policia) MERGE dbo.Usuario AS T USING S ON T.UserName = S.UserName WHEN NOT MATCHED BY TARGET THEN INSERT (UserName,PasswordHash,FuncionarioId,RolId,CreatedAt) VALUES(S.UserName,S.PwdHash,S.FuncionarioId,2,GETDATE());
+    ;WITH SourceUsuarios AS (
+        SELECT
+            LOWER(LTRIM(RTRIM(u.usuario))) COLLATE DATABASE_DEFAULT AS NombreUsuario,
+            HASHBYTES('SHA2_256', CAST(u.clave AS NVARCHAR(4000))) AS PasswordHash,
+            mp.FuncionarioId,
+            LTRIM(RTRIM(p.nom_policia)) COLLATE DATABASE_DEFAULT AS NombreCompleto
+        FROM Personal.dbo.tblUsuarios u
+        LEFT JOIN dbo.MapPoliciaFunc mp ON mp.id_policia = u.id_policia
+        LEFT JOIN Personal.dbo.tblPolicias p ON p.id_policia = u.id_policia
+    )
+    MERGE dbo.Usuario AS T
+    USING SourceUsuarios AS S
+        ON T.NombreUsuario = S.NombreUsuario
+    WHEN NOT MATCHED BY TARGET THEN
+        INSERT (NombreUsuario, PasswordHash, PasswordSalt, NombreCompleto, Activo, FechaCreacion, FuncionarioId)
+        VALUES (
+            S.NombreUsuario,
+            S.PasswordHash,
+            0x,
+            ISNULL(NULLIF(S.NombreCompleto, ''), S.NombreUsuario),
+            1,
+            GETDATE(),
+            S.FuncionarioId
+        );
+
+    ;WITH SourceUsuarioRol AS (
+        SELECT
+            LOWER(LTRIM(RTRIM(u.usuario))) COLLATE DATABASE_DEFAULT AS NombreUsuario,
+            CASE UPPER(LTRIM(RTRIM(u.rol)))
+                WHEN 'ADMIN' THEN 1
+                WHEN 'SUPERADMIN' THEN 1
+                WHEN 'USUARIO' THEN 2
+                ELSE 2
+            END AS RolId
+        FROM Personal.dbo.tblUsuarios u
+    )
+    INSERT INTO dbo.UsuarioRol (UsuarioId, RolId)
+    SELECT u.Id, sur.RolId
+    FROM SourceUsuarioRol sur
+    JOIN dbo.Usuario u ON u.NombreUsuario = sur.NombreUsuario
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM dbo.UsuarioRol ur
+        WHERE ur.UsuarioId = u.Id
+          AND ur.RolId = sur.RolId
+    );
     PRINT '✔ Datos relacionados migrados.';
 
     /*================================================================


### PR DESCRIPTION
## Summary
- ensure the consolidated migration seeds the base Rol entries expected by UsuarioRol
- keep RolUsuario catalog in sync with the seeded core roles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d83858b0448326952300fcd128fa9e