### PR TITLE
Improve documentation and clean comments on custom forms

### DIFF
--- a/Apex/UI/frmFuncionarioEstadoTransitorio.vb
+++ b/Apex/UI/frmFuncionarioEstadoTransitorio.vb
@@ -568,9 +568,8 @@ Fin:
                 d.FechaResolucion = fechaResolucionSel
                 Estado.Funcionario.CargoId = cargoNuevoId
 
-                ' ▼▼▼ LÍNEA A AGREGAR ▼▼▼
-                ' Notificamos al UnitOfWork que la entidad Funcionario ha cambiado
-                ' para que guarde la modificación del CargoId.
+                ' Informa al UnitOfWork que la entidad Funcionario fue modificada
+                ' para que persista el nuevo CargoId.
                 _unitOfWork.Repository(Of Funcionario).Update(Estado.Funcionario)
 
             Case ModConstantesApex.TipoEstadoTransitorioId.ReactivacionDeFuncionario


### PR DESCRIPTION
## Summary
- replace informal annotations in frmUsuarioCrear with descriptive XML documentation and focused inline comments
- rewrite export workflow comments in frmFiltros to describe behaviour and adjust helper documentation
- clarify search- and state-related comments across frmFuncionarioBuscar and frmFuncionarioEstadoTransitorio

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da056956008326a5b6442dcd74ef01