### PR TITLE
Evitar desbordes al calcular el rango de fechas

### DIFF
--- a/Apex/UI/frmFuncionarioSituacion.vb
+++ b/Apex/UI/frmFuncionarioSituacion.vb
@@ -84,7 +84,12 @@ Public Class frmFuncionarioSituacion
 
     Private Async Function ActualizarTodo() As Task
         Dim fechaInicio = dtpDesde.Value.Date
-        Dim fechaFin = dtpHasta.Value.Date.AddDays(1) ' Rango semi-abierto [inicio, fin)
+        Dim fechaFin = dtpHasta.Value.Date
+
+        ' Evitar desbordes al trabajar con fechas máximas permitidas por el control.
+        If fechaFin < DateTime.MaxValue.Date Then
+            fechaFin = fechaFin.AddDays(1) ' Rango semi-abierto [inicio, fin)
+        End If
 
         GenerarTimeline(fechaInicio, fechaFin)
         Await PoblarGrillaEstados(fechaInicio, fechaFin)


### PR DESCRIPTION
## Summary
- evitar que el cálculo del rango final genere una excepción cuando la fecha seleccionada es la máxima permitida
- mantener el comportamiento de rango semi-abierto sin provocar desbordes

## Testing
- dotnet build *(falla: comando no disponible en el entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68db45c161bc8326b00de546988ad1ad