### PR TITLE
Adjust funcionario search grid column sizing

### DIFF
--- a/Apex/UI/frmFuncionarioBuscar.vb
+++ b/Apex/UI/frmFuncionarioBuscar.vb
@@ -413,6 +413,7 @@ Public Class frmFuncionarioBuscar
             .AllowUserToResizeRows = False
             .AutoGenerateColumns = False
             .BackgroundColor = Color.White
+            .AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill
 
             ' --- ESTILO DE ENCABEZADOS (Headers) ---
             .EnableHeadersVisualStyles = False
@@ -441,19 +442,22 @@ Public Class frmFuncionarioBuscar
 
             .Columns.Add(New DataGridViewTextBoxColumn With {
             .Name = "CI", .DataPropertyName = "CI", .HeaderText = "Cédula",
-            .AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells, ' Se ajusta al contenido
-            .MinimumWidth = 90
+            .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill,
+            .FillWeight = 30,
+            .MinimumWidth = 100
         })
 
             .Columns.Add(New DataGridViewTextBoxColumn With {
             .Name = "Nombre", .DataPropertyName = "Nombre", .HeaderText = "Nombre",
-            .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill, ' Ocupa el espacio restante
+            .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill,
+            .FillWeight = 45,
             .MinimumWidth = 200
         })
 
             .Columns.Add(New DataGridViewTextBoxColumn With {
             .Name = "Cargo", .DataPropertyName = "CargoNombre", .HeaderText = "Cargo",
-            .AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells, ' Se ajusta al contenido
+            .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill,
+            .FillWeight = 25,
             .MinimumWidth = 150
         })
         End With


### PR DESCRIPTION
## Summary
- enable fill-based autosizing for the funcionario search grid
- tune column fill weights and minimum widths to keep key data visible during dashboard resizing

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68dbbcbc4fe083269d45c3d4513a4a0c