### PR TITLE
Center funcionario name label

### DIFF
--- a/Apex/UI/frmFuncionarioBuscar.Designer.vb
+++ b/Apex/UI/frmFuncionarioBuscar.Designer.vb
@@ -211,14 +211,15 @@ Partial Class frmFuncionarioBuscar
         'lblNombreCompleto
         '
         Me.lblNombreCompleto.Anchor = System.Windows.Forms.AnchorStyles.Left
-        Me.lblNombreCompleto.AutoSize = True
+        Me.lblNombreCompleto.AutoSize = False
         Me.lblNombreCompleto.Font = New System.Drawing.Font("Segoe UI", 14.0!, System.Drawing.FontStyle.Bold)
         Me.lblNombreCompleto.Location = New System.Drawing.Point(3, 8)
         Me.lblNombreCompleto.Margin = New System.Windows.Forms.Padding(3, 8, 3, 8)
         Me.lblNombreCompleto.Name = "lblNombreCompleto"
-        Me.lblNombreCompleto.Size = New System.Drawing.Size(288, 38)
+        Me.lblNombreCompleto.Size = New System.Drawing.Size(624, 38)
         Me.lblNombreCompleto.TabIndex = 2
         Me.lblNombreCompleto.Text = "Nombre Funcionario"
+        Me.lblNombreCompleto.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
         'lblCI
         '

--- a/Apex/UI/frmFuncionarioBuscar.vb
+++ b/Apex/UI/frmFuncionarioBuscar.vb
@@ -1313,6 +1313,12 @@ Public Class frmFuncionarioBuscar
             lbl.MaximumSize = New Size(anchoDisponible, 0) ' 0 = altura auto
             lbl.AutoEllipsis = True
         Next
+
+        Dim preferido = lblNombreCompleto.GetPreferredSize(New Size(anchoDisponible, 0))
+        lblNombreCompleto.MinimumSize = New Size(anchoDisponible, 0)
+        lblNombreCompleto.MaximumSize = New Size(anchoDisponible, 0)
+        lblNombreCompleto.Size = New Size(anchoDisponible, preferido.Height)
+        lblNombreCompleto.TextAlign = ContentAlignment.MiddleCenter
     End Sub
 
     ' Reduce el flicker en la grilla cuando se redimensiona


### PR DESCRIPTION
## Summary
- center the funcionario name label within the detail panel so it aligns better with the photo
- adjust resize handling to keep the name label width and centering consistent when the form resizes

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68dd7474ac408326aaa1a4f7dfdfbdbd