### PR TITLE
Ajustar apertura de novedades desde búsqueda de funcionarios

### DIFF
--- a/Apex/UI/frmFuncionarioBuscar.vb
+++ b/Apex/UI/frmFuncionarioBuscar.vb
@@ -355,10 +355,11 @@ Public Class frmFuncionarioBuscar
     End Sub
 
     Private Sub btnNovedades_Click(sender As Object, e As EventArgs) Handles btnNovedades.Click
-        If FuncionarioSeleccionado IsNot Nothing Then
+        Dim funcionario = FuncionarioSeleccionado
+        If funcionario IsNot Nothing Then
             ' Abre el formulario de novedades, idealmente filtrando por el funcionario.
             Dim frm As New frmNovedades()
-            ' frm.FiltrarPorFuncionario(FuncionarioSeleccionado.Id) ' (Si el form lo soporta)
+            frm.ConfigurarParaFuncionario(funcionario.Id, funcionario.Nombre)
             NavegacionHelper.AbrirNuevaInstanciaEnDashboard(frm)
         End If
     End Sub

--- a/Apex/UI/frmNovedades.vb
+++ b/Apex/UI/frmNovedades.vb
@@ -22,6 +22,21 @@ Public Class frmNovedades
         InitializeComponent()
     End Sub
 
+    Public Sub ConfigurarParaFuncionario(funcionarioId As Integer, funcionarioNombre As String)
+        If funcionarioId <= 0 Then Return
+
+        chkFiltrarPorFecha.Checked = False
+
+        _funcionariosSeleccionadosFiltro.Clear()
+        _funcionariosSeleccionadosFiltro(funcionarioId) = funcionarioNombre
+        ActualizarListaFuncionarios()
+
+        If Me.IsHandleCreated Then
+            Dim tk = ReiniciarToken()
+            _ = BuscarAsync(tk)
+        End If
+    End Sub
+
 #Region "Ciclo de Vida y Eventos Principales"
 
     Private Async Sub frmNovedades_Load(sender As Object, e As EventArgs) Handles MyBase.Load


### PR DESCRIPTION
## Summary
- evita que el filtro por fecha quede activo al abrir Novedades desde la búsqueda de funcionarios
- preselecciona al funcionario elegido en la lista de filtros y dispara la búsqueda inicial correspondiente

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de068213688326a2280b98c87ee967