### PR TITLE
Adjust column sizing in funcionario search grid

### DIFF
--- a/Apex/UI/frmFuncionarioBuscar.vb
+++ b/Apex/UI/frmFuncionarioBuscar.vb
@@ -466,16 +466,17 @@ Public Class frmFuncionarioBuscar
 
             .Columns.Add(New DataGridViewTextBoxColumn With {
             .Name = "CI", .DataPropertyName = "CI", .HeaderText = "Cédula",
-            .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill,
-            .FillWeight = 30,
-            .MinimumWidth = 75
+            .AutoSizeMode = DataGridViewAutoSizeColumnMode.None,
+            .Width = 115,
+            .MinimumWidth = 100
         })
 
             .Columns.Add(New DataGridViewTextBoxColumn With {
             .Name = "Nombre", .DataPropertyName = "Nombre", .HeaderText = "Nombre",
             .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill,
-            .FillWeight = 40,
-            .MinimumWidth = 165
+            .FillWeight = 100,
+            .MinimumWidth = 220,
+            .DefaultCellStyle = New DataGridViewCellStyle With {.WrapMode = DataGridViewTriState.False}
         })
         End With
 


### PR DESCRIPTION
## Summary
- fix DataGridView column sizing for funcionario search so names have enough space

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de25f03fd08326b031bd209b9e00c5