### PR TITLE
Ensure reactivating funcionario clears baja state

### DIFF
--- a/Apex/UI/frmFuncionarioCrear.vb
+++ b/Apex/UI/frmFuncionarioCrear.vb
@@ -1016,6 +1016,10 @@ Public Class frmFuncionarioCrear
             ' Esa lógica se encargará de crear o eliminar el estado de baja según corresponda.
             ' No necesitamos hacer nada más aquí.
         End If
+
+        ' Aseguramos la sincronización incluso si el evento de dtpBaja no se dispara
+        ' (p. ej. cuando el check se modificó programáticamente).
+        SincronizarEstadoBajaDesdePicker()
     End Sub
     Private Sub ProcesarCambioFechaBaja()
         If _bloquearEventosBaja Then Return


### PR DESCRIPTION
## Summary
- force the baja picker to re-synchronize after toggling the Activo checkbox so that the state is removed when reactivating a funcionario

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68decf5267f08326b849353b6c7ceb7b