### PR TITLE
Fix button layout in frmFusionarFunciones

### DIFF
--- a/Apex/UI/frmFusionarFunciones.Designer.vb
+++ b/Apex/UI/frmFusionarFunciones.Designer.vb
@@ -208,6 +208,8 @@ Partial Class frmFusionarFunciones
         '
         'pnlBotones
         '
+        Me.pnlBotones.AutoSize = True
+        Me.pnlBotones.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
         Me.pnlBotones.Controls.Add(Me.btnAceptar)
         Me.pnlBotones.Controls.Add(Me.btnCancelar)
         Me.pnlBotones.Dock = System.Windows.Forms.DockStyle.Fill
@@ -215,7 +217,7 @@ Partial Class frmFusionarFunciones
         Me.pnlBotones.Location = New System.Drawing.Point(3, 489)
         Me.pnlBotones.Name = "pnlBotones"
         Me.pnlBotones.Padding = New System.Windows.Forms.Padding(0, 10, 0, 0)
-        Me.pnlBotones.Size = New System.Drawing.Size(538, 40)
+        Me.pnlBotones.Size = New System.Drawing.Size(538, 46)
         Me.pnlBotones.TabIndex = 6
         '
         'btnAceptar


### PR DESCRIPTION
## Summary
- ensure the button panel in frmFusionarFunciones auto-sizes to accommodate its buttons
- prevent the Accept and Cancel buttons from being clipped at the bottom of the form

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df3e68ca688326bda715bf93b487ce