### PR TITLE
Corregir visualización del destino en frmFusionarFunciones

### DIFF
--- a/Apex/UI/frmFusionarFunciones.vb
+++ b/Apex/UI/frmFusionarFunciones.vb
@@ -106,6 +106,8 @@ Public Class frmFusionarFunciones
         End If
 
         cboFuncionPrincipal.DataSource = seleccionadas
+        cboFuncionPrincipal.DisplayMember = NameOf(Funcion.Nombre)
+        cboFuncionPrincipal.ValueMember = NameOf(Funcion.Id)
 
         Dim indiceSeleccion = -1
         If destinoActual.HasValue Then


### PR DESCRIPTION
## Summary
- restablecer la configuración de DisplayMember y ValueMember al actualizar el combo de función principal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df4429f10083268055b4c37bf2f82a