### PR TITLE
Add Unidad General management screen

### DIFF
--- a/Apex/Apex.vbproj
+++ b/Apex/Apex.vbproj
@@ -423,6 +423,7 @@
     <Compile Include="DataBase\Turno.vb">
       <DependentUpon>Model1.tt</DependentUpon>
     </Compile>
+    <Compile Include="DataBase\UnidadGeneral.Metadata.vb" />
     <Compile Include="DataBase\UnidadGeneral.vb">
       <DependentUpon>Model1.tt</DependentUpon>
     </Compile>
@@ -502,6 +503,7 @@
     <Compile Include="Services\SeccionService.vb" />
     <Compile Include="Services\EscalafonService.vb" />
     <Compile Include="Services\SubDireccionService.vb" />
+    <Compile Include="Services\UnidadGeneralService.vb" />
     <Compile Include="Services\FuncionService.vb" />
     <Compile Include="Services\TipoEstadoTransitorioService.vb" />
     <Compile Include="Services\TiposEstadoCatalog.vb" />
@@ -601,6 +603,12 @@
       <DependentUpon>frmSubDirecciones.vb</DependentUpon>
     </Compile>
     <Compile Include="UI\frmSubDirecciones.vb">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="UI\frmUnidadesGenerales.Designer.vb">
+      <DependentUpon>frmUnidadesGenerales.vb</DependentUpon>
+    </Compile>
+    <Compile Include="UI\frmUnidadesGenerales.vb">
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="UI\frmDashboard.Designer.vb">
@@ -894,6 +902,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="UI\frmSubDirecciones.resx">
       <DependentUpon>frmSubDirecciones.vb</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UI\frmUnidadesGenerales.resx">
+      <DependentUpon>frmUnidadesGenerales.vb</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="UI\frmDashboard.resx">
       <DependentUpon>frmDashboard.vb</DependentUpon>

--- a/Apex/DataBase/UnidadGeneral.Metadata.vb
+++ b/Apex/DataBase/UnidadGeneral.Metadata.vb
@@ -1,0 +1,13 @@
+Imports System.ComponentModel.DataAnnotations.Schema
+
+Partial Public Class UnidadGeneral
+    <NotMapped>
+    Public Property Id As Integer
+        Get
+            Return UnidadGeneralId
+        End Get
+        Set(value As Integer)
+            UnidadGeneralId = value
+        End Set
+    End Property
+End Class

--- a/Apex/Services/UnidadGeneralService.vb
+++ b/Apex/Services/UnidadGeneralService.vb
@@ -1,0 +1,26 @@
+Option Strict On
+Option Explicit On
+
+Imports System.Data.Entity
+Imports System.Linq
+
+Public Class UnidadGeneralService
+    Inherits GenericService(Of UnidadGeneral)
+
+    Public Sub New()
+        MyBase.New(New UnitOfWork())
+    End Sub
+
+    Public Sub New(unitOfWork As IUnitOfWork)
+        MyBase.New(unitOfWork)
+    End Sub
+
+    Public Async Function ObtenerUnidadesOrdenadasAsync() As Task(Of List(Of UnidadGeneral))
+        Dim lista = Await _unitOfWork.Repository(Of UnidadGeneral)().
+            GetAll().
+            OrderBy(Function(u) u.Nombre).
+            ToListAsync()
+
+        Return lista
+    End Function
+End Class

--- a/Apex/UI/frmConfiguracion.Designer.vb
+++ b/Apex/UI/frmConfiguracion.Designer.vb
@@ -29,6 +29,7 @@ Partial Class frmConfiguracion
         Me.btnGestionarIncidencias = New System.Windows.Forms.Button()
         Me.FlowLayoutPanel1 = New System.Windows.Forms.FlowLayoutPanel()
         Me.btnSubDirecciones = New System.Windows.Forms.Button()
+        Me.btnUnidadesGenerales = New System.Windows.Forms.Button()
         Me.btnNomenclaturas = New System.Windows.Forms.Button()
         Me.btnEscalafones = New System.Windows.Forms.Button()
         Me.btnFunciones = New System.Windows.Forms.Button()
@@ -93,6 +94,7 @@ Partial Class frmConfiguracion
         Me.FlowLayoutPanel1.Controls.Add(Me.btnTurnos)
         Me.FlowLayoutPanel1.Controls.Add(Me.btnGestionarIncidencias)
         Me.FlowLayoutPanel1.Controls.Add(Me.btnSubDirecciones)
+        Me.FlowLayoutPanel1.Controls.Add(Me.btnUnidadesGenerales)
         Me.FlowLayoutPanel1.Controls.Add(Me.btnNomenclaturas)
         Me.FlowLayoutPanel1.Controls.Add(Me.btnEscalafones)
         Me.FlowLayoutPanel1.Controls.Add(Me.btnFunciones)
@@ -112,9 +114,19 @@ Partial Class frmConfiguracion
         Me.btnSubDirecciones.Text = "Gestionar Subdirecciones"
         Me.btnSubDirecciones.UseVisualStyleBackColor = True
         '
+        'btnUnidadesGenerales
+        '
+        Me.btnUnidadesGenerales.Location = New System.Drawing.Point(4, 140)
+        Me.btnUnidadesGenerales.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.btnUnidadesGenerales.Name = "btnUnidadesGenerales"
+        Me.btnUnidadesGenerales.Size = New System.Drawing.Size(285, 35)
+        Me.btnUnidadesGenerales.TabIndex = 12
+        Me.btnUnidadesGenerales.Text = "Gestionar Unidades Generales"
+        Me.btnUnidadesGenerales.UseVisualStyleBackColor = True
+        '
         'btnNomenclaturas
         '
-        Me.btnNomenclaturas.Location = New System.Drawing.Point(4, 140)
+        Me.btnNomenclaturas.Location = New System.Drawing.Point(297, 140)
         Me.btnNomenclaturas.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.btnNomenclaturas.Name = "btnNomenclaturas"
         Me.btnNomenclaturas.Size = New System.Drawing.Size(285, 35)
@@ -124,7 +136,7 @@ Partial Class frmConfiguracion
         '
         'btnEscalafones
         '
-        Me.btnEscalafones.Location = New System.Drawing.Point(297, 140)
+        Me.btnEscalafones.Location = New System.Drawing.Point(4, 185)
         Me.btnEscalafones.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.btnEscalafones.Name = "btnEscalafones"
         Me.btnEscalafones.Size = New System.Drawing.Size(285, 35)
@@ -134,7 +146,7 @@ Partial Class frmConfiguracion
         '
         'btnFunciones
         '
-        Me.btnFunciones.Location = New System.Drawing.Point(4, 185)
+        Me.btnFunciones.Location = New System.Drawing.Point(297, 185)
         Me.btnFunciones.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.btnFunciones.Name = "btnFunciones"
         Me.btnFunciones.Size = New System.Drawing.Size(285, 35)
@@ -164,6 +176,7 @@ Partial Class frmConfiguracion
     Friend WithEvents btnGestionarIncidencias As Button
     Friend WithEvents FlowLayoutPanel1 As FlowLayoutPanel
     Friend WithEvents btnSubDirecciones As Button
+    Friend WithEvents btnUnidadesGenerales As Button
     Friend WithEvents btnNomenclaturas As Button
     Friend WithEvents btnEscalafones As Button
     Friend WithEvents btnFunciones As Button

--- a/Apex/UI/frmConfiguracion.vb
+++ b/Apex/UI/frmConfiguracion.vb
@@ -19,7 +19,7 @@
         ' ---- Normalizar botones (texto, tamaño mínimo, márgenes)
         Dim botones() As Button = {
         btnCargos, btnSecciones, btnAreasTrabajo, btnTurnos,
-        btnGestionarIncidencias, btnSubDirecciones, btnNomenclaturas, btnEscalafones,
+        btnGestionarIncidencias, btnSubDirecciones, btnUnidadesGenerales, btnNomenclaturas, btnEscalafones,
         btnFunciones
     }
 
@@ -105,6 +105,10 @@
 
     Private Sub btnSubDirecciones_Click(sender As Object, e As EventArgs) Handles btnSubDirecciones.Click
         AbrirHijoEnDashboard(Of frmSubDirecciones)()
+    End Sub
+
+    Private Sub btnUnidadesGenerales_Click(sender As Object, e As EventArgs) Handles btnUnidadesGenerales.Click
+        AbrirHijoEnDashboard(Of frmUnidadesGenerales)()
     End Sub
 
     Private Sub btnEscalafones_Click(sender As Object, e As EventArgs) Handles btnEscalafones.Click

--- a/Apex/UI/frmDashboard.vb
+++ b/Apex/UI/frmDashboard.vb
@@ -37,7 +37,8 @@ Public Class frmDashboard
         {GetType(frmRenombrarPDF), New String() {"txtCarpeta", "txtRuta", "txtPrefijo", "btnSeleccionarCarpeta"}},
         {GetType(frmAsistenteImportacion), New String() {"txtArchivo", "btnSeleccionarArchivo"}},
         {GetType(frmViaticosListas), New String() {"txtBuscar", "txtBusqueda", "txtFiltro"}},
-        {GetType(frmConfiguracion), New String() {"txtBuscar", "txtBusqueda", "txtRuta", "txtCarpeta"}}
+        {GetType(frmConfiguracion), New String() {"txtBuscar", "txtBusqueda", "txtRuta", "txtCarpeta"}},
+        {GetType(frmUnidadesGenerales), New String() {"txtBuscar", "txtNombre"}}
     }
 
     ' ========= NAVEGACIÓN ACTUAL =========

--- a/Apex/UI/frmUnidadesGenerales.Designer.vb
+++ b/Apex/UI/frmUnidadesGenerales.Designer.vb
@@ -1,0 +1,243 @@
+<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()>
+Partial Class frmUnidadesGenerales
+    Inherits System.Windows.Forms.Form
+
+    <System.Diagnostics.DebuggerNonUserCode()>
+    Protected Overrides Sub Dispose(disposing As Boolean)
+        Try
+            If disposing AndAlso components IsNot Nothing Then
+                components.Dispose()
+            End If
+        Finally
+            MyBase.Dispose(disposing)
+        End Try
+    End Sub
+
+    Private components As System.ComponentModel.IContainer
+
+    <System.Diagnostics.DebuggerStepThrough()>
+    Private Sub InitializeComponent()
+        Me.TableLayoutPanelMain = New System.Windows.Forms.TableLayoutPanel()
+        Me.PanelListado = New System.Windows.Forms.Panel()
+        Me.dgvUnidadesGenerales = New System.Windows.Forms.DataGridView()
+        Me.PanelBusqueda = New System.Windows.Forms.Panel()
+        Me.txtBuscar = New System.Windows.Forms.TextBox()
+        Me.lblBuscar = New System.Windows.Forms.Label()
+        Me.PanelEdicion = New System.Windows.Forms.Panel()
+        Me.FlowLayoutPanelBotones = New System.Windows.Forms.FlowLayoutPanel()
+        Me.btnNuevo = New System.Windows.Forms.Button()
+        Me.btnGuardar = New System.Windows.Forms.Button()
+        Me.btnEliminar = New System.Windows.Forms.Button()
+        Me.btnCerrar = New System.Windows.Forms.Button()
+        Me.txtNombre = New System.Windows.Forms.TextBox()
+        Me.lblNombre = New System.Windows.Forms.Label()
+        Me.TableLayoutPanelMain.SuspendLayout()
+        Me.PanelListado.SuspendLayout()
+        CType(Me.dgvUnidadesGenerales, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.PanelBusqueda.SuspendLayout()
+        Me.PanelEdicion.SuspendLayout()
+        Me.FlowLayoutPanelBotones.SuspendLayout()
+        Me.SuspendLayout()
+        '
+        'TableLayoutPanelMain
+        '
+        Me.TableLayoutPanelMain.ColumnCount = 2
+        Me.TableLayoutPanelMain.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 55.0!))
+        Me.TableLayoutPanelMain.ColumnStyles.Add(New System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 45.0!))
+        Me.TableLayoutPanelMain.Controls.Add(Me.PanelListado, 0, 0)
+        Me.TableLayoutPanelMain.Controls.Add(Me.PanelEdicion, 1, 0)
+        Me.TableLayoutPanelMain.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.TableLayoutPanelMain.Location = New System.Drawing.Point(0, 0)
+        Me.TableLayoutPanelMain.Name = "TableLayoutPanelMain"
+        Me.TableLayoutPanelMain.RowCount = 1
+        Me.TableLayoutPanelMain.RowStyles.Add(New System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100.0!))
+        Me.TableLayoutPanelMain.Size = New System.Drawing.Size(884, 481)
+        Me.TableLayoutPanelMain.TabIndex = 0
+        '
+        'PanelListado
+        '
+        Me.PanelListado.Controls.Add(Me.dgvUnidadesGenerales)
+        Me.PanelListado.Controls.Add(Me.PanelBusqueda)
+        Me.PanelListado.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.PanelListado.Location = New System.Drawing.Point(3, 3)
+        Me.PanelListado.Name = "PanelListado"
+        Me.PanelListado.Padding = New System.Windows.Forms.Padding(10)
+        Me.PanelListado.Size = New System.Drawing.Size(479, 475)
+        Me.PanelListado.TabIndex = 0
+        '
+        'dgvUnidadesGenerales
+        '
+        Me.dgvUnidadesGenerales.AllowUserToAddRows = False
+        Me.dgvUnidadesGenerales.AllowUserToDeleteRows = False
+        Me.dgvUnidadesGenerales.AllowUserToResizeRows = False
+        Me.dgvUnidadesGenerales.BackgroundColor = System.Drawing.Color.White
+        Me.dgvUnidadesGenerales.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize
+        Me.dgvUnidadesGenerales.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.dgvUnidadesGenerales.Location = New System.Drawing.Point(10, 66)
+        Me.dgvUnidadesGenerales.MultiSelect = False
+        Me.dgvUnidadesGenerales.Name = "dgvUnidadesGenerales"
+        Me.dgvUnidadesGenerales.ReadOnly = True
+        Me.dgvUnidadesGenerales.RowHeadersVisible = False
+        Me.dgvUnidadesGenerales.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect
+        Me.dgvUnidadesGenerales.Size = New System.Drawing.Size(459, 399)
+        Me.dgvUnidadesGenerales.TabIndex = 1
+        '
+        'PanelBusqueda
+        '
+        Me.PanelBusqueda.Controls.Add(Me.txtBuscar)
+        Me.PanelBusqueda.Controls.Add(Me.lblBuscar)
+        Me.PanelBusqueda.Dock = System.Windows.Forms.DockStyle.Top
+        Me.PanelBusqueda.Location = New System.Drawing.Point(10, 10)
+        Me.PanelBusqueda.Name = "PanelBusqueda"
+        Me.PanelBusqueda.Padding = New System.Windows.Forms.Padding(0, 0, 0, 10)
+        Me.PanelBusqueda.Size = New System.Drawing.Size(459, 56)
+        Me.PanelBusqueda.TabIndex = 0
+        '
+        'txtBuscar
+        '
+        Me.txtBuscar.Dock = System.Windows.Forms.DockStyle.Top
+        Me.txtBuscar.Location = New System.Drawing.Point(0, 25)
+        Me.txtBuscar.Name = "txtBuscar"
+        Me.txtBuscar.Size = New System.Drawing.Size(459, 26)
+        Me.txtBuscar.TabIndex = 1
+        '
+        'lblBuscar
+        '
+        Me.lblBuscar.Dock = System.Windows.Forms.DockStyle.Top
+        Me.lblBuscar.Location = New System.Drawing.Point(0, 0)
+        Me.lblBuscar.Name = "lblBuscar"
+        Me.lblBuscar.Size = New System.Drawing.Size(459, 25)
+        Me.lblBuscar.TabIndex = 0
+        Me.lblBuscar.Text = "Buscar"
+        Me.lblBuscar.TextAlign = System.Drawing.ContentAlignment.BottomLeft
+        '
+        'PanelEdicion
+        '
+        Me.PanelEdicion.Controls.Add(Me.FlowLayoutPanelBotones)
+        Me.PanelEdicion.Controls.Add(Me.txtNombre)
+        Me.PanelEdicion.Controls.Add(Me.lblNombre)
+        Me.PanelEdicion.Dock = System.Windows.Forms.DockStyle.Fill
+        Me.PanelEdicion.Location = New System.Drawing.Point(488, 3)
+        Me.PanelEdicion.Name = "PanelEdicion"
+        Me.PanelEdicion.Padding = New System.Windows.Forms.Padding(20)
+        Me.PanelEdicion.Size = New System.Drawing.Size(393, 475)
+        Me.PanelEdicion.TabIndex = 1
+        '
+        'FlowLayoutPanelBotones
+        '
+        Me.FlowLayoutPanelBotones.Anchor = CType(((System.Windows.Forms.AnchorStyles.Bottom Or System.Windows.Forms.AnchorStyles.Left) Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.FlowLayoutPanelBotones.AutoSize = True
+        Me.FlowLayoutPanelBotones.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.FlowLayoutPanelBotones.Controls.Add(Me.btnNuevo)
+        Me.FlowLayoutPanelBotones.Controls.Add(Me.btnGuardar)
+        Me.FlowLayoutPanelBotones.Controls.Add(Me.btnEliminar)
+        Me.FlowLayoutPanelBotones.Controls.Add(Me.btnCerrar)
+        Me.FlowLayoutPanelBotones.FlowDirection = System.Windows.Forms.FlowDirection.LeftToRight
+        Me.FlowLayoutPanelBotones.Location = New System.Drawing.Point(20, 388)
+        Me.FlowLayoutPanelBotones.Name = "FlowLayoutPanelBotones"
+        Me.FlowLayoutPanelBotones.Size = New System.Drawing.Size(353, 84)
+        Me.FlowLayoutPanelBotones.TabIndex = 2
+        Me.FlowLayoutPanelBotones.WrapContents = False
+        '
+        'btnNuevo
+        '
+        Me.btnNuevo.AutoSize = True
+        Me.btnNuevo.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.btnNuevo.Margin = New System.Windows.Forms.Padding(0, 0, 10, 0)
+        Me.btnNuevo.Name = "btnNuevo"
+        Me.btnNuevo.Padding = New System.Windows.Forms.Padding(10, 6, 10, 6)
+        Me.btnNuevo.Size = New System.Drawing.Size(87, 39)
+        Me.btnNuevo.TabIndex = 0
+        Me.btnNuevo.Text = "Nuevo"
+        Me.btnNuevo.UseVisualStyleBackColor = True
+        '
+        'btnGuardar
+        '
+        Me.btnGuardar.AutoSize = True
+        Me.btnGuardar.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.btnGuardar.Margin = New System.Windows.Forms.Padding(0, 0, 10, 0)
+        Me.btnGuardar.Name = "btnGuardar"
+        Me.btnGuardar.Padding = New System.Windows.Forms.Padding(10, 6, 10, 6)
+        Me.btnGuardar.Size = New System.Drawing.Size(104, 39)
+        Me.btnGuardar.TabIndex = 1
+        Me.btnGuardar.Text = "Guardar"
+        Me.btnGuardar.UseVisualStyleBackColor = True
+        '
+        'btnEliminar
+        '
+        Me.btnEliminar.AutoSize = True
+        Me.btnEliminar.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.btnEliminar.Margin = New System.Windows.Forms.Padding(0, 0, 10, 0)
+        Me.btnEliminar.Name = "btnEliminar"
+        Me.btnEliminar.Padding = New System.Windows.Forms.Padding(10, 6, 10, 6)
+        Me.btnEliminar.Size = New System.Drawing.Size(101, 39)
+        Me.btnEliminar.TabIndex = 2
+        Me.btnEliminar.Text = "Eliminar"
+        Me.btnEliminar.UseVisualStyleBackColor = True
+        '
+        'btnCerrar
+        '
+        Me.btnCerrar.AutoSize = True
+        Me.btnCerrar.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink
+        Me.btnCerrar.Name = "btnCerrar"
+        Me.btnCerrar.Padding = New System.Windows.Forms.Padding(10, 6, 10, 6)
+        Me.btnCerrar.Size = New System.Drawing.Size(81, 39)
+        Me.btnCerrar.TabIndex = 3
+        Me.btnCerrar.Text = "Cerrar"
+        Me.btnCerrar.UseVisualStyleBackColor = True
+        '
+        'txtNombre
+        '
+        Me.txtNombre.Anchor = CType(((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Left) Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.txtNombre.Location = New System.Drawing.Point(20, 92)
+        Me.txtNombre.Name = "txtNombre"
+        Me.txtNombre.Size = New System.Drawing.Size(353, 26)
+        Me.txtNombre.TabIndex = 1
+        '
+        'lblNombre
+        '
+        Me.lblNombre.AutoSize = True
+        Me.lblNombre.Location = New System.Drawing.Point(17, 65)
+        Me.lblNombre.Name = "lblNombre"
+        Me.lblNombre.Size = New System.Drawing.Size(146, 20)
+        Me.lblNombre.TabIndex = 0
+        Me.lblNombre.Text = "Nombre unidad general"
+        '
+        'frmUnidadesGenerales
+        '
+        Me.AutoScaleDimensions = New System.Drawing.SizeF(9.0!, 20.0!)
+        Me.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font
+        Me.ClientSize = New System.Drawing.Size(884, 481)
+        Me.Controls.Add(Me.TableLayoutPanelMain)
+        Me.MinimumSize = New System.Drawing.Size(900, 520)
+        Me.Name = "frmUnidadesGenerales"
+        Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent
+        Me.Text = "Gestión de Unidades Generales"
+        Me.TableLayoutPanelMain.ResumeLayout(False)
+        Me.PanelListado.ResumeLayout(False)
+        CType(Me.dgvUnidadesGenerales, System.ComponentModel.ISupportInitialize).EndInit()
+        Me.PanelBusqueda.ResumeLayout(False)
+        Me.PanelBusqueda.PerformLayout()
+        Me.PanelEdicion.ResumeLayout(False)
+        Me.PanelEdicion.PerformLayout()
+        Me.FlowLayoutPanelBotones.ResumeLayout(False)
+        Me.FlowLayoutPanelBotones.PerformLayout()
+        Me.ResumeLayout(False)
+
+    End Sub
+
+    Friend WithEvents TableLayoutPanelMain As TableLayoutPanel
+    Friend WithEvents PanelListado As Panel
+    Friend WithEvents dgvUnidadesGenerales As DataGridView
+    Friend WithEvents PanelBusqueda As Panel
+    Friend WithEvents txtBuscar As TextBox
+    Friend WithEvents lblBuscar As Label
+    Friend WithEvents PanelEdicion As Panel
+    Friend WithEvents FlowLayoutPanelBotones As FlowLayoutPanel
+    Friend WithEvents btnNuevo As Button
+    Friend WithEvents btnGuardar As Button
+    Friend WithEvents btnEliminar As Button
+    Friend WithEvents btnCerrar As Button
+    Friend WithEvents txtNombre As TextBox
+    Friend WithEvents lblNombre As Label
+End Class

--- a/Apex/UI/frmUnidadesGenerales.resx
+++ b/Apex/UI/frmUnidadesGenerales.resx
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Apex/UI/frmUnidadesGenerales.vb
+++ b/Apex/UI/frmUnidadesGenerales.vb
@@ -1,0 +1,266 @@
+Imports System.ComponentModel
+Imports System.Data.Entity
+Imports System.Drawing
+Imports System.Linq
+Imports System.Threading.Tasks
+Imports System.Windows.Forms
+
+Public Class frmUnidadesGenerales
+
+    Private _listaCompleta As List(Of UnidadGeneral)
+    Private ReadOnly _bindingSource As New BindingSource()
+    Private _seleccionActual As UnidadGeneral
+    Private _estaCargando As Boolean
+    Private _ultimoIdSeleccionado As Integer
+
+    Private Async Sub frmUnidadesGenerales_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        AppTheme.Aplicar(Me)
+        Me.AcceptButton = btnGuardar
+        Me.KeyPreview = True
+
+        ConfigurarGrilla()
+        Try
+            AppTheme.SetCue(txtBuscar, "Buscar unidades generales...")
+            AppTheme.SetCue(txtNombre, "Nombre de la unidad general")
+        Catch
+        End Try
+
+        Await CargarDatosAsync()
+        PrepararEventos()
+        LimpiarFormulario()
+    End Sub
+
+    Private Sub PrepararEventos()
+        AddHandler Me.KeyDown, AddressOf frmUnidadesGenerales_KeyDown
+        AddHandler dgvUnidadesGenerales.CellDoubleClick, AddressOf dgvUnidadesGenerales_CellDoubleClick
+    End Sub
+
+    Private Sub ConfigurarGrilla()
+        dgvUnidadesGenerales.AutoGenerateColumns = False
+        dgvUnidadesGenerales.Columns.Clear()
+
+        dgvUnidadesGenerales.EnableHeadersVisualStyles = False
+        dgvUnidadesGenerales.ColumnHeadersBorderStyle = DataGridViewHeaderBorderStyle.None
+        dgvUnidadesGenerales.ColumnHeadersDefaultCellStyle.BackColor = Color.FromArgb(28, 41, 56)
+        dgvUnidadesGenerales.ColumnHeadersDefaultCellStyle.ForeColor = Color.White
+        dgvUnidadesGenerales.ColumnHeadersDefaultCellStyle.Font = New Font("Segoe UI", 9.75F, FontStyle.Bold)
+        dgvUnidadesGenerales.ColumnHeadersHeight = 40
+        dgvUnidadesGenerales.DefaultCellStyle.Font = New Font("Segoe UI", 9.5F)
+        dgvUnidadesGenerales.DefaultCellStyle.SelectionBackColor = Color.FromArgb(51, 153, 255)
+        dgvUnidadesGenerales.DefaultCellStyle.SelectionForeColor = Color.White
+        dgvUnidadesGenerales.AlternatingRowsDefaultCellStyle.BackColor = Color.FromArgb(242, 245, 247)
+        dgvUnidadesGenerales.BorderStyle = BorderStyle.None
+        dgvUnidadesGenerales.CellBorderStyle = DataGridViewCellBorderStyle.SingleHorizontal
+
+        dgvUnidadesGenerales.Columns.Add(New DataGridViewTextBoxColumn With {
+            .DataPropertyName = NameOf(UnidadGeneral.Id),
+            .Visible = False
+        })
+
+        dgvUnidadesGenerales.Columns.Add(New DataGridViewTextBoxColumn With {
+            .DataPropertyName = NameOf(UnidadGeneral.Nombre),
+            .HeaderText = "Nombre",
+            .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
+        })
+    End Sub
+
+    Private Async Function CargarDatosAsync() As Task
+        If _estaCargando Then Return
+        _estaCargando = True
+
+        Cursor = Cursors.WaitCursor
+        dgvUnidadesGenerales.Enabled = False
+
+        Try
+            Using svc As New UnidadGeneralService()
+                Dim lista = Await svc.ObtenerUnidadesOrdenadasAsync()
+                _listaCompleta = lista.ToList()
+            End Using
+
+            AplicarFiltro(txtBuscar.Text.Trim())
+            SeleccionarFilaPorId(_ultimoIdSeleccionado)
+        Catch ex As Exception
+            Notifier.Error(Me, $"No se pudieron cargar las unidades generales: {ex.Message}")
+            _listaCompleta = New List(Of UnidadGeneral)()
+            _bindingSource.DataSource = _listaCompleta
+            dgvUnidadesGenerales.DataSource = _bindingSource
+        Finally
+            dgvUnidadesGenerales.Enabled = True
+            Cursor = Cursors.Default
+            _estaCargando = False
+        End Try
+    End Function
+
+    Private Sub AplicarFiltro(filtro As String)
+        If _listaCompleta Is Nothing Then Return
+
+        Dim listaFiltrada = _listaCompleta
+        If Not String.IsNullOrWhiteSpace(filtro) Then
+            listaFiltrada = _listaCompleta.
+                Where(Function(u) u.Nombre IsNot Nothing AndAlso
+                                   u.Nombre.IndexOf(filtro, StringComparison.OrdinalIgnoreCase) >= 0).
+                OrderBy(Function(u) u.Nombre).
+                ToList()
+        Else
+            listaFiltrada = _listaCompleta.OrderBy(Function(u) u.Nombre).ToList()
+        End If
+
+        _bindingSource.DataSource = listaFiltrada
+        dgvUnidadesGenerales.DataSource = _bindingSource
+
+        SeleccionarFilaPorId(_ultimoIdSeleccionado)
+    End Sub
+
+    Private Sub SeleccionarFilaPorId(id As Integer)
+        If id <= 0 OrElse dgvUnidadesGenerales.Rows.Count = 0 Then
+            dgvUnidadesGenerales.ClearSelection()
+            _seleccionActual = Nothing
+            Return
+        End If
+
+        For Each row As DataGridViewRow In dgvUnidadesGenerales.Rows
+            Dim elemento = TryCast(row.DataBoundItem, UnidadGeneral)
+            If elemento IsNot Nothing AndAlso elemento.Id = id Then
+                row.Selected = True
+                Dim firstVisible = dgvUnidadesGenerales.Columns.GetFirstColumn(DataGridViewElementStates.Visible)
+                If firstVisible IsNot Nothing Then
+                    dgvUnidadesGenerales.CurrentCell = row.Cells(firstVisible.Index)
+                ElseIf row.Cells.Count > 0 Then
+                    dgvUnidadesGenerales.CurrentCell = row.Cells(0)
+                End If
+                dgvUnidadesGenerales.FirstDisplayedScrollingRowIndex = Math.Max(0, row.Index)
+                _seleccionActual = elemento
+                MostrarDetalle()
+                Exit Sub
+            End If
+        Next
+
+        dgvUnidadesGenerales.ClearSelection()
+        _seleccionActual = Nothing
+    End Sub
+
+    Private Sub MostrarDetalle()
+        If _seleccionActual Is Nothing Then
+            txtNombre.Clear()
+            btnEliminar.Enabled = False
+            Return
+        End If
+
+        txtNombre.Text = _seleccionActual.Nombre
+        btnEliminar.Enabled = (_seleccionActual.Id > 0)
+    End Sub
+
+    Private Sub LimpiarFormulario()
+        _seleccionActual = Nothing
+        _ultimoIdSeleccionado = 0
+        txtNombre.Clear()
+        txtNombre.Focus()
+        btnEliminar.Enabled = False
+        dgvUnidadesGenerales.ClearSelection()
+    End Sub
+
+    Private Sub dgvUnidadesGenerales_SelectionChanged(sender As Object, e As EventArgs) Handles dgvUnidadesGenerales.SelectionChanged
+        If dgvUnidadesGenerales.CurrentRow Is Nothing Then Return
+        _seleccionActual = TryCast(dgvUnidadesGenerales.CurrentRow.DataBoundItem, UnidadGeneral)
+        If _seleccionActual IsNot Nothing Then
+            _ultimoIdSeleccionado = _seleccionActual.Id
+        End If
+        MostrarDetalle()
+    End Sub
+
+    Private Sub dgvUnidadesGenerales_CellDoubleClick(sender As Object, e As DataGridViewCellEventArgs)
+        If e.RowIndex >= 0 Then
+            txtNombre.Focus()
+            txtNombre.SelectAll()
+        End If
+    End Sub
+
+    Private Sub txtBuscar_TextChanged(sender As Object, e As EventArgs) Handles txtBuscar.TextChanged
+        AplicarFiltro(txtBuscar.Text.Trim())
+    End Sub
+
+    Private Async Sub btnGuardar_Click(sender As Object, e As EventArgs) Handles btnGuardar.Click
+        Dim nombre = txtNombre.Text.Trim()
+        If String.IsNullOrWhiteSpace(nombre) Then
+            Notifier.Warn(Me, "Debes ingresar un nombre para la unidad general.")
+            txtNombre.Focus()
+            Return
+        End If
+
+        Try
+            Using svc As New UnidadGeneralService()
+                If _seleccionActual Is Nothing OrElse _seleccionActual.Id = 0 Then
+                    Dim entidad = New UnidadGeneral With {
+                        .Nombre = nombre,
+                        .EsActivo = True,
+                        .FechaCreacion = DateTime.Now,
+                        .UsuarioCreacion = ObtenerNombreUsuario()
+                    }
+                    Dim nuevoId = Await svc.CreateAsync(entidad)
+                    _ultimoIdSeleccionado = nuevoId
+                    Notifier.Success(Me, "Unidad general creada correctamente.")
+                Else
+                    _seleccionActual.Nombre = nombre
+                    _seleccionActual.FechaActualizacion = DateTime.Now
+                    _seleccionActual.UsuarioActualizacion = ObtenerNombreUsuario()
+                    Await svc.UpdateAsync(_seleccionActual)
+                    _ultimoIdSeleccionado = _seleccionActual.Id
+                    Notifier.Success(Me, "Unidad general actualizada correctamente.")
+                End If
+            End Using
+
+            Await CargarDatosAsync()
+            SeleccionarFilaPorId(_ultimoIdSeleccionado)
+        Catch ex As Exception
+            Notifier.Error(Me, $"No se pudo guardar la unidad general: {ex.Message}")
+        End Try
+    End Sub
+
+    Private Async Sub btnEliminar_Click(sender As Object, e As EventArgs) Handles btnEliminar.Click
+        If _seleccionActual Is Nothing OrElse _seleccionActual.Id = 0 Then Return
+
+        Dim respuesta = MessageBox.Show(
+            "¿Seguro que deseas eliminar la unidad general seleccionada?", "Confirmación",
+            MessageBoxButtons.YesNo, MessageBoxIcon.Question)
+
+        If respuesta <> DialogResult.Yes Then Return
+
+        Try
+            Using svc As New UnidadGeneralService()
+                Await svc.DeleteAsync(_seleccionActual.Id)
+            End Using
+
+            Notifier.Success(Me, "Unidad general eliminada correctamente.")
+            _ultimoIdSeleccionado = 0
+            Await CargarDatosAsync()
+            LimpiarFormulario()
+        Catch ex As Exception
+            Notifier.Error(Me, $"No se pudo eliminar la unidad general: {ex.Message}")
+        End Try
+    End Sub
+
+    Private Sub btnNuevo_Click(sender As Object, e As EventArgs) Handles btnNuevo.Click
+        LimpiarFormulario()
+    End Sub
+
+    Private Sub btnCerrar_Click(sender As Object, e As EventArgs) Handles btnCerrar.Click
+        Close()
+    End Sub
+
+    Private Sub frmUnidadesGenerales_KeyDown(sender As Object, e As KeyEventArgs)
+        If e.KeyCode = Keys.Escape Then
+            Close()
+        End If
+    End Sub
+
+    Private Function ObtenerNombreUsuario() As String
+        Try
+            Dim usuario = Environment.UserName
+            If Not String.IsNullOrWhiteSpace(usuario) Then
+                Return usuario
+            End If
+        Catch
+        End Try
+        Return "Sistema"
+    End Function
+End Class


### PR DESCRIPTION
## Summary
- expose a not-mapped Id alias so UnidadGeneral entities can reuse the generic CRUD helpers
- add a dedicated UnidadGeneralService with an ordered query helper
- introduce frmUnidadesGenerales for listing, filtering, creating, editing and deleting Unidad General records and link it from the configuration menu and dashboard focus map

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68df57ce1e248326b8a7a8316b833e8d