### PR TITLE
Evitar String.IsNullOrWhiteSpace en consultas de licencias

### DIFF
--- a/Apex/Services/LicenciaService.vb
+++ b/Apex/Services/LicenciaService.vb
@@ -152,11 +152,18 @@ Public Class LicenciaService
             Dim query = context.HistoricoLicencia.AsNoTracking().AsQueryable()
             query = AplicarFiltroFechas(query, fechaInicio, fechaFin)
 
-            Return query.
+            Dim agrupados = query.
                 GroupBy(Function(l) l.estado).
+                Select(Function(g) New With {
+                    .Estado = g.Key,
+                    .Cantidad = g.Count()
+                }).
+                ToList()
+
+            Return agrupados.
                 Select(Function(g) New EstadisticaItem With {
-                    .Etiqueta = If(Not String.IsNullOrWhiteSpace(g.Key), g.Key, "Sin especificar"),
-                    .Valor = g.Count()
+                    .Etiqueta = If(String.IsNullOrWhiteSpace(g.Estado), "Sin especificar", g.Estado),
+                    .Valor = g.Cantidad
                 }).
                 OrderByDescending(Function(item) item.Valor).
                 ToList()
@@ -174,14 +181,22 @@ Public Class LicenciaService
 
             Dim limite = If(topN > 0, topN, 10)
 
-            Return query.
+            Dim agrupados = query.
                 GroupBy(Function(l) New With {
                              Key .Id = l.FuncionarioId,
                              Key .Nombre = l.Funcionario.Nombre
                          }).
+                Select(Function(g) New With {
+                    .Nombre = g.Key.Nombre,
+                    .Id = g.Key.Id,
+                    .Cantidad = g.Count()
+                }).
+                ToList()
+
+            Return agrupados.
                 Select(Function(g) New EstadisticaItem With {
-                    .Etiqueta = If(Not String.IsNullOrWhiteSpace(g.Key.Nombre), g.Key.Nombre, $"Funcionario #{g.Key.Id}"),
-                    .Valor = g.Count()
+                    .Etiqueta = If(String.IsNullOrWhiteSpace(g.Nombre), $"Funcionario #{g.Id}", g.Nombre),
+                    .Valor = g.Cantidad
                 }).
                 OrderByDescending(Function(item) item.Valor).
                 Take(limite).


### PR DESCRIPTION
## Summary
- reestructura la estadística de licencias por estado para materializar resultados antes de usar String.IsNullOrWhiteSpace
- ajusta la estadística de funcionarios con licencias para evitar funciones no traducibles por Entity Framework

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfda51f5bc83268fdcab44f287cdaa