### PR TITLE
Add new staffing distribution reports

### DIFF
--- a/Apex/Apex.vbproj
+++ b/Apex/Apex.vbproj
@@ -740,7 +740,16 @@
     <Compile Include="UI\frmReporteFuncionariosEdad.vb">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="UI\frmReporteFuncionariosEstado.vb">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="UI\frmReporteFuncionariosGenero.vb">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="UI\frmReporteFuncionariosNivelEstudio.vb">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="UI\frmReporteFuncionariosTurno.vb">
       <SubType>Form</SubType>
     </Compile>
     <Compile Include="UI\frmReporteLicenciasPorEstado.vb">

--- a/Apex/Services/FuncionarioService.vb
+++ b/Apex/Services/FuncionarioService.vb
@@ -370,6 +370,47 @@ Public Class FuncionarioService
         End Using
     End Function
 
+    Public Function GetDistribucionPorEstado() As List(Of EstadisticaItem)
+        Using context As New ApexEntities()
+            Return context.Funcionario.
+                GroupBy(Function(f) f.Activo).
+                Select(Function(g) New EstadisticaItem With {
+                    .Etiqueta = If(g.Key, "Activos", "Inactivos"),
+                    .Valor = g.Count()
+                }).
+                OrderByDescending(Function(item) item.Valor).
+                ToList()
+        End Using
+    End Function
+
+    Public Function GetDistribucionPorTurno() As List(Of EstadisticaItem)
+        Using context As New ApexEntities()
+            Return context.Funcionario.
+                Where(Function(f) f.Activo).
+                GroupBy(Function(f) f.Turno.Nombre).
+                Select(Function(g) New EstadisticaItem With {
+                    .Etiqueta = If(g.Key IsNot Nothing, g.Key, "Sin especificar"),
+                    .Valor = g.Count()
+                }).
+                OrderByDescending(Function(item) item.Valor).
+                ToList()
+        End Using
+    End Function
+
+    Public Function GetDistribucionPorNivelEstudio() As List(Of EstadisticaItem)
+        Using context As New ApexEntities()
+            Return context.Funcionario.
+                Where(Function(f) f.Activo).
+                GroupBy(Function(f) f.NivelEstudio.Nombre).
+                Select(Function(g) New EstadisticaItem With {
+                    .Etiqueta = If(g.Key IsNot Nothing, g.Key, "Sin especificar"),
+                    .Valor = g.Count()
+                }).
+                OrderByDescending(Function(item) item.Valor).
+                ToList()
+        End Using
+    End Function
+
 
     Public Async Function ObtenerPresenciasParaFechaAsync(fecha As Date) As Task(Of List(Of PresenciaDTO))
         Using uow As New UnitOfWork()

--- a/Apex/UI/frmReporteFuncionariosEstado.vb
+++ b/Apex/UI/frmReporteFuncionariosEstado.vb
@@ -1,0 +1,86 @@
+Option Strict On
+Option Explicit On
+
+Imports System.Drawing
+Imports System.Linq
+Imports System.Threading.Tasks
+Imports System.Windows.Forms.DataVisualization.Charting
+
+Public Class frmReporteFuncionariosEstado
+    Inherits Form
+
+    Private ReadOnly _funcionarioService As New FuncionarioService()
+    Private ReadOnly chartEstado As Chart
+
+    Public Sub New()
+        chartEstado = New Chart()
+        InitializeComponent()
+    End Sub
+
+    Private Sub InitializeComponent()
+        Dim chartArea As New ChartArea("ChartAreaEstado")
+        Dim legend As New Legend("LegendEstado")
+        Dim title As New Title("Funcionarios por Estado")
+
+        SuspendLayout()
+
+        chartArea.BackColor = Color.White
+        chartEstado.ChartAreas.Add(chartArea)
+        chartEstado.Dock = DockStyle.Fill
+        legend.Docking = Docking.Bottom
+        chartEstado.Legends.Add(legend)
+        chartEstado.Location = New Point(0, 0)
+        chartEstado.Name = "chartEstado"
+        chartEstado.Palette = ChartColorPalette.BrightPastel
+        title.Font = New Font("Segoe UI", 12.0!, FontStyle.Bold)
+        chartEstado.Titles.Add(title)
+        chartEstado.TabIndex = 0
+
+        AutoScaleDimensions = New SizeF(9.0!, 20.0!)
+        AutoScaleMode = AutoScaleMode.Font
+        ClientSize = New Size(900, 600)
+        Controls.Add(chartEstado)
+        MinimumSize = New Size(520, 360)
+        Name = "frmReporteFuncionariosEstado"
+        StartPosition = FormStartPosition.CenterParent
+        Text = "Funcionarios Activos vs. Inactivos"
+
+        ResumeLayout(False)
+    End Sub
+
+    Private Async Sub frmReporteFuncionariosEstado_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        Try
+            AppTheme.Aplicar(Me)
+        Catch
+        End Try
+
+        Await CargarGraficoAsync()
+    End Sub
+
+    Private Async Function CargarGraficoAsync() As Task
+        Dim datos = Await Task.Run(Function() _funcionarioService.GetDistribucionPorEstado())
+
+        If chartEstado.Titles.Count > 0 Then
+            chartEstado.Titles(0).Text = "Funcionarios por Estado"
+        End If
+        chartEstado.Series.Clear()
+
+        If datos Is Nothing OrElse Not datos.Any() Then
+            If chartEstado.Titles.Count > 0 Then
+                chartEstado.Titles(0).Text = "Funcionarios por Estado - Sin datos"
+            End If
+            Return
+        End If
+
+        Dim series As New Series("Estado") With {
+            .ChartType = SeriesChartType.Pie,
+            .IsValueShownAsLabel = True
+        }
+
+        For Each item In datos
+            series.Points.AddXY(item.Etiqueta, item.Valor)
+        Next
+
+        chartEstado.Series.Add(series)
+    End Function
+End Class

--- a/Apex/UI/frmReporteFuncionariosNivelEstudio.vb
+++ b/Apex/UI/frmReporteFuncionariosNivelEstudio.vb
@@ -1,0 +1,93 @@
+Option Strict On
+Option Explicit On
+
+Imports System.Drawing
+Imports System.Linq
+Imports System.Threading.Tasks
+Imports System.Windows.Forms.DataVisualization.Charting
+
+Public Class frmReporteFuncionariosNivelEstudio
+    Inherits Form
+
+    Private ReadOnly _funcionarioService As New FuncionarioService()
+    Private ReadOnly chartNivel As Chart
+
+    Public Sub New()
+        chartNivel = New Chart()
+        InitializeComponent()
+    End Sub
+
+    Private Sub InitializeComponent()
+        Dim chartArea As New ChartArea("ChartAreaNivel")
+        Dim legend As New Legend("LegendNivel")
+        Dim title As New Title("Funcionarios por Nivel de Estudios")
+
+        SuspendLayout()
+
+        chartArea.AxisX.Interval = 1
+        chartArea.AxisX.MajorGrid.Enabled = False
+        chartArea.AxisY.MajorGrid.LineDashStyle = ChartDashStyle.Dash
+        chartNivel.ChartAreas.Add(chartArea)
+        chartNivel.Dock = DockStyle.Fill
+        legend.Enabled = False
+        chartNivel.Legends.Add(legend)
+        chartNivel.Location = New Point(0, 0)
+        chartNivel.Name = "chartNivel"
+        chartNivel.Palette = ChartColorPalette.Berry
+        title.Font = New Font("Segoe UI", 12.0!, FontStyle.Bold)
+        chartNivel.Titles.Add(title)
+        chartNivel.TabIndex = 0
+
+        AutoScaleDimensions = New SizeF(9.0!, 20.0!)
+        AutoScaleMode = AutoScaleMode.Font
+        ClientSize = New Size(900, 600)
+        Controls.Add(chartNivel)
+        MinimumSize = New Size(600, 400)
+        Name = "frmReporteFuncionariosNivelEstudio"
+        StartPosition = FormStartPosition.CenterParent
+        Text = "Distribución de Funcionarios por Nivel de Estudios"
+
+        ResumeLayout(False)
+    End Sub
+
+    Private Async Sub frmReporteFuncionariosNivelEstudio_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        Try
+            AppTheme.Aplicar(Me)
+        Catch
+        End Try
+
+        Await CargarGraficoAsync()
+    End Sub
+
+    Private Async Function CargarGraficoAsync() As Task
+        Dim datos = Await Task.Run(Function() _funcionarioService.GetDistribucionPorNivelEstudio())
+
+        If chartNivel.Titles.Count > 0 Then
+            chartNivel.Titles(0).Text = "Funcionarios por Nivel de Estudios"
+        End If
+        chartNivel.Series.Clear()
+
+        If datos Is Nothing OrElse Not datos.Any() Then
+            If chartNivel.Titles.Count > 0 Then
+                chartNivel.Titles(0).Text = "Funcionarios por Nivel de Estudios - Sin datos"
+            End If
+            Return
+        End If
+
+        Dim series As New Series("Nivel de estudios") With {
+            .ChartType = SeriesChartType.Column,
+            .IsValueShownAsLabel = True
+        }
+
+        For Each item In datos
+            Dim point As New DataPoint()
+            point.SetValueY(item.Valor)
+            point.AxisLabel = item.Etiqueta
+            point.Label = item.Valor.ToString()
+            series.Points.Add(point)
+        Next
+
+        chartNivel.Series.Add(series)
+        chartNivel.ChartAreas(0).AxisX.Interval = 1
+    End Function
+End Class

--- a/Apex/UI/frmReporteFuncionariosTurno.vb
+++ b/Apex/UI/frmReporteFuncionariosTurno.vb
@@ -1,0 +1,93 @@
+Option Strict On
+Option Explicit On
+
+Imports System.Drawing
+Imports System.Linq
+Imports System.Threading.Tasks
+Imports System.Windows.Forms.DataVisualization.Charting
+
+Public Class frmReporteFuncionariosTurno
+    Inherits Form
+
+    Private ReadOnly _funcionarioService As New FuncionarioService()
+    Private ReadOnly chartTurno As Chart
+
+    Public Sub New()
+        chartTurno = New Chart()
+        InitializeComponent()
+    End Sub
+
+    Private Sub InitializeComponent()
+        Dim chartArea As New ChartArea("ChartAreaTurno")
+        Dim legend As New Legend("LegendTurno")
+        Dim title As New Title("Funcionarios por Turno")
+
+        SuspendLayout()
+
+        chartArea.AxisX.Interval = 1
+        chartArea.AxisX.MajorGrid.Enabled = False
+        chartArea.AxisY.MajorGrid.LineDashStyle = ChartDashStyle.Dash
+        chartTurno.ChartAreas.Add(chartArea)
+        chartTurno.Dock = DockStyle.Fill
+        legend.Enabled = False
+        chartTurno.Legends.Add(legend)
+        chartTurno.Location = New Point(0, 0)
+        chartTurno.Name = "chartTurno"
+        chartTurno.Palette = ChartColorPalette.SeaGreen
+        title.Font = New Font("Segoe UI", 12.0!, FontStyle.Bold)
+        chartTurno.Titles.Add(title)
+        chartTurno.TabIndex = 0
+
+        AutoScaleDimensions = New SizeF(9.0!, 20.0!)
+        AutoScaleMode = AutoScaleMode.Font
+        ClientSize = New Size(900, 600)
+        Controls.Add(chartTurno)
+        MinimumSize = New Size(600, 400)
+        Name = "frmReporteFuncionariosTurno"
+        StartPosition = FormStartPosition.CenterParent
+        Text = "Distribución de Funcionarios por Turno"
+
+        ResumeLayout(False)
+    End Sub
+
+    Private Async Sub frmReporteFuncionariosTurno_Load(sender As Object, e As EventArgs) Handles MyBase.Load
+        Try
+            AppTheme.Aplicar(Me)
+        Catch
+        End Try
+
+        Await CargarGraficoAsync()
+    End Sub
+
+    Private Async Function CargarGraficoAsync() As Task
+        Dim datos = Await Task.Run(Function() _funcionarioService.GetDistribucionPorTurno())
+
+        If chartTurno.Titles.Count > 0 Then
+            chartTurno.Titles(0).Text = "Funcionarios por Turno"
+        End If
+        chartTurno.Series.Clear()
+
+        If datos Is Nothing OrElse Not datos.Any() Then
+            If chartTurno.Titles.Count > 0 Then
+                chartTurno.Titles(0).Text = "Funcionarios por Turno - Sin datos"
+            End If
+            Return
+        End If
+
+        Dim series As New Series("Turnos") With {
+            .ChartType = SeriesChartType.Bar,
+            .IsValueShownAsLabel = True
+        }
+
+        For Each item In datos
+            Dim point As New DataPoint()
+            point.SetValueY(item.Valor)
+            point.AxisLabel = item.Etiqueta
+            point.Label = item.Valor.ToString()
+            series.Points.Add(point)
+        Next
+
+        chartTurno.Series.Add(series)
+        chartTurno.ChartAreas(0).AxisX.Interval = 1
+    End Function
+End Class

--- a/Apex/UI/frmReportes.Designer.vb
+++ b/Apex/UI/frmReportes.Designer.vb
@@ -27,6 +27,9 @@ Partial Class frmReportes
         Me.btnFuncionariosEdad = New System.Windows.Forms.Button()
         Me.btnFuncionariosArea = New System.Windows.Forms.Button()
         Me.btnFuncionariosCargo = New System.Windows.Forms.Button()
+        Me.btnFuncionariosEstado = New System.Windows.Forms.Button()
+        Me.btnFuncionariosTurno = New System.Windows.Forms.Button()
+        Me.btnFuncionariosNivelEstudio = New System.Windows.Forms.Button()
         Me.btnLicenciasPorTipo = New System.Windows.Forms.Button()
         Me.btnLicenciasPorEstado = New System.Windows.Forms.Button()
         Me.btnLicenciasTopFuncionarios = New System.Windows.Forms.Button()
@@ -84,33 +87,63 @@ Partial Class frmReportes
         Me.btnFuncionariosCargo.Text = "🧭 Top Cargos con más Personal"
         Me.btnFuncionariosCargo.UseVisualStyleBackColor = True
         '
+        'btnFuncionariosEstado
+        '
+        Me.btnFuncionariosEstado.Location = New System.Drawing.Point(4, 230)
+        Me.btnFuncionariosEstado.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.btnFuncionariosEstado.Name = "btnFuncionariosEstado"
+        Me.btnFuncionariosEstado.Size = New System.Drawing.Size(330, 35)
+        Me.btnFuncionariosEstado.TabIndex = 7
+        Me.btnFuncionariosEstado.Text = "🟢 Activos vs. Inactivos"
+        Me.btnFuncionariosEstado.UseVisualStyleBackColor = True
+        '
+        'btnFuncionariosTurno
+        '
+        Me.btnFuncionariosTurno.Location = New System.Drawing.Point(4, 275)
+        Me.btnFuncionariosTurno.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.btnFuncionariosTurno.Name = "btnFuncionariosTurno"
+        Me.btnFuncionariosTurno.Size = New System.Drawing.Size(330, 35)
+        Me.btnFuncionariosTurno.TabIndex = 8
+        Me.btnFuncionariosTurno.Text = "⏰ Distribución por Turno"
+        Me.btnFuncionariosTurno.UseVisualStyleBackColor = True
+        '
+        'btnFuncionariosNivelEstudio
+        '
+        Me.btnFuncionariosNivelEstudio.Location = New System.Drawing.Point(4, 320)
+        Me.btnFuncionariosNivelEstudio.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.btnFuncionariosNivelEstudio.Name = "btnFuncionariosNivelEstudio"
+        Me.btnFuncionariosNivelEstudio.Size = New System.Drawing.Size(330, 35)
+        Me.btnFuncionariosNivelEstudio.TabIndex = 9
+        Me.btnFuncionariosNivelEstudio.Text = "🎓 Nivel de Estudios"
+        Me.btnFuncionariosNivelEstudio.UseVisualStyleBackColor = True
+        '
         'btnLicenciasPorTipo
         '
-        Me.btnLicenciasPorTipo.Location = New System.Drawing.Point(4, 230)
+        Me.btnLicenciasPorTipo.Location = New System.Drawing.Point(4, 365)
         Me.btnLicenciasPorTipo.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.btnLicenciasPorTipo.Name = "btnLicenciasPorTipo"
         Me.btnLicenciasPorTipo.Size = New System.Drawing.Size(330, 35)
-        Me.btnLicenciasPorTipo.TabIndex = 7
+        Me.btnLicenciasPorTipo.TabIndex = 10
         Me.btnLicenciasPorTipo.Text = "🗂️ Licencias por Tipo"
         Me.btnLicenciasPorTipo.UseVisualStyleBackColor = True
         '
         'btnLicenciasPorEstado
         '
-        Me.btnLicenciasPorEstado.Location = New System.Drawing.Point(4, 275)
+        Me.btnLicenciasPorEstado.Location = New System.Drawing.Point(4, 410)
         Me.btnLicenciasPorEstado.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.btnLicenciasPorEstado.Name = "btnLicenciasPorEstado"
         Me.btnLicenciasPorEstado.Size = New System.Drawing.Size(330, 35)
-        Me.btnLicenciasPorEstado.TabIndex = 8
+        Me.btnLicenciasPorEstado.TabIndex = 11
         Me.btnLicenciasPorEstado.Text = "📑 Licencias por Estado"
         Me.btnLicenciasPorEstado.UseVisualStyleBackColor = True
         '
         'btnLicenciasTopFuncionarios
         '
-        Me.btnLicenciasTopFuncionarios.Location = New System.Drawing.Point(4, 320)
+        Me.btnLicenciasTopFuncionarios.Location = New System.Drawing.Point(4, 455)
         Me.btnLicenciasTopFuncionarios.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
         Me.btnLicenciasTopFuncionarios.Name = "btnLicenciasTopFuncionarios"
         Me.btnLicenciasTopFuncionarios.Size = New System.Drawing.Size(330, 35)
-        Me.btnLicenciasTopFuncionarios.TabIndex = 9
+        Me.btnLicenciasTopFuncionarios.TabIndex = 12
         Me.btnLicenciasTopFuncionarios.Text = "🏅 Funcionarios con más Licencias"
         Me.btnLicenciasTopFuncionarios.UseVisualStyleBackColor = True
         '
@@ -122,6 +155,9 @@ Partial Class frmReportes
         Me.FlowLayoutPanel1.Controls.Add(Me.btnFuncionariosEdad)
         Me.FlowLayoutPanel1.Controls.Add(Me.btnFuncionariosArea)
         Me.FlowLayoutPanel1.Controls.Add(Me.btnFuncionariosCargo)
+        Me.FlowLayoutPanel1.Controls.Add(Me.btnFuncionariosEstado)
+        Me.FlowLayoutPanel1.Controls.Add(Me.btnFuncionariosTurno)
+        Me.FlowLayoutPanel1.Controls.Add(Me.btnFuncionariosNivelEstudio)
         Me.FlowLayoutPanel1.Controls.Add(Me.btnLicenciasPorTipo)
         Me.FlowLayoutPanel1.Controls.Add(Me.btnLicenciasPorEstado)
         Me.FlowLayoutPanel1.Controls.Add(Me.btnLicenciasTopFuncionarios)
@@ -157,5 +193,8 @@ Partial Class frmReportes
     Friend WithEvents btnLicenciasPorTipo As Button
     Friend WithEvents btnLicenciasPorEstado As Button
     Friend WithEvents btnLicenciasTopFuncionarios As Button
+    Friend WithEvents btnFuncionariosEstado As Button
+    Friend WithEvents btnFuncionariosTurno As Button
+    Friend WithEvents btnFuncionariosNivelEstudio As Button
     Friend WithEvents FlowLayoutPanel1 As FlowLayoutPanel
 End Class

--- a/Apex/UI/frmReportes.vb
+++ b/Apex/UI/frmReportes.vb
@@ -21,6 +21,18 @@ Public Class frmReportes
         AbrirFormularioReporte(Of frmReporteFuncionariosCargo)()
     End Sub
 
+    Private Sub btnFuncionariosEstado_Click(sender As Object, e As EventArgs) Handles btnFuncionariosEstado.Click
+        AbrirFormularioReporte(Of frmReporteFuncionariosEstado)()
+    End Sub
+
+    Private Sub btnFuncionariosTurno_Click(sender As Object, e As EventArgs) Handles btnFuncionariosTurno.Click
+        AbrirFormularioReporte(Of frmReporteFuncionariosTurno)()
+    End Sub
+
+    Private Sub btnFuncionariosNivelEstudio_Click(sender As Object, e As EventArgs) Handles btnFuncionariosNivelEstudio.Click
+        AbrirFormularioReporte(Of frmReporteFuncionariosNivelEstudio)()
+    End Sub
+
     Private Sub btnLicenciasPorTipo_Click(sender As Object, e As EventArgs) Handles btnLicenciasPorTipo.Click
         AbrirFormularioReporte(Of frmReporteLicenciasPorTipo)()
     End Sub
@@ -54,6 +66,9 @@ Public Class frmReportes
             btnFuncionariosEdad,
             btnFuncionariosArea,
             btnFuncionariosCargo,
+            btnFuncionariosEstado,
+            btnFuncionariosTurno,
+            btnFuncionariosNivelEstudio,
             btnLicenciasPorTipo,
             btnLicenciasPorEstado,
             btnLicenciasTopFuncionarios


### PR DESCRIPTION
## Summary
- add service helpers to compute staff distribution by estado, turno, and nivel de estudio
- create three WinForms report viewers to visualize the new distributions
- expose the new reports from the reports menu and include the forms in the project

## Testing
- not run (desktop application)

------
https://chatgpt.com/codex/tasks/task_e_68dfe9708dd08326b775f887d84fca5a