### PR TITLE
Add attendance reports by section and job role

### DIFF
--- a/Apex/Apex.vbproj
+++ b/Apex/Apex.vbproj
@@ -752,6 +752,13 @@
     <Compile Include="UI\frmReporteFuncionariosTurno.vb">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="UI\frmReportePresenciasBase.vb" />
+    <Compile Include="UI\frmReportePresenciasPorPuestoTrabajo.vb">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="UI\frmReportePresenciasPorSeccion.vb">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="UI\frmReporteLicenciasPorEstado.vb">
       <SubType>Form</SubType>
     </Compile>

--- a/Apex/UI/frmReportePresenciasBase.vb
+++ b/Apex/UI/frmReportePresenciasBase.vb
@@ -1,0 +1,275 @@
+Option Strict On
+Option Explicit On
+
+Imports System.Collections.Generic
+Imports System.ComponentModel
+Imports System.Drawing
+Imports System.Linq
+Imports System.Threading.Tasks
+Imports System.Windows.Forms
+
+Public MustInherit Class frmReportePresenciasBase
+    Inherits Form
+
+    Private ReadOnly _funcionarioService As New FuncionarioService()
+    Private ReadOnly _rbPresentes As RadioButton
+    Private ReadOnly _rbAusentes As RadioButton
+    Private ReadOnly _lblEstado As Label
+    Private ReadOnly _bsGrupos As BindingSource
+    Private ReadOnly _bsFuncionarios As BindingSource
+    Private ReadOnly _dgvGrupos As DataGridView
+    Private ReadOnly _dgvFuncionarios As DataGridView
+    Private ReadOnly _toolTip As ToolTip
+    Private ReadOnly _splitContainer As SplitContainer
+
+    Private _cargando As Boolean
+
+    Protected Sub New()
+        DoubleBuffered = True
+
+        _rbPresentes = New RadioButton() With {
+            .Text = "Presentes",
+            .AutoSize = True,
+            .Checked = True
+        }
+
+        _rbAusentes = New RadioButton() With {
+            .Text = "Ausentes",
+            .AutoSize = True,
+            .Margin = New Padding(18, 0, 0, 0)
+        }
+
+        _lblEstado = New Label() With {
+            .Dock = DockStyle.Fill,
+            .TextAlign = ContentAlignment.MiddleRight,
+            .AutoSize = False,
+            .ForeColor = SystemColors.GrayText
+        }
+
+        _bsGrupos = New BindingSource() With {
+            .DataSource = GetType(PresenciaAgrupada)
+        }
+
+        _bsFuncionarios = New BindingSource() With {
+            .DataSource = GetType(PresenciaFuncionarioDetalle)
+        }
+
+        _dgvGrupos = New DataGridView()
+        _dgvFuncionarios = New DataGridView()
+        _toolTip = New ToolTip()
+        _splitContainer = New SplitContainer()
+
+        InitializeComponent()
+    End Sub
+
+    Protected MustOverride ReadOnly Property Agrupacion As AgrupacionPresencia
+    Protected MustOverride ReadOnly Property TituloFormulario As String
+    Protected MustOverride ReadOnly Property EtiquetaGrupo As String
+
+    Protected Overridable ReadOnly Property TooltipAusentes As String
+        Get
+            Return "Funcionarios activos sin marcar como presentes en la fecha consultada."
+        End Get
+    End Property
+
+    Protected Overridable Function ObtenerFechaConsulta() As Date
+        Return Date.Today
+    End Function
+
+    Private Sub InitializeComponent()
+        SuspendLayout()
+
+        Dim panelSuperior As New TableLayoutPanel() With {
+            .ColumnCount = 2,
+            .Dock = DockStyle.Top,
+            .AutoSize = True,
+            .AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            .Padding = New Padding(12, 12, 12, 6)
+        }
+        panelSuperior.ColumnStyles.Add(New ColumnStyle(SizeType.AutoSize))
+        panelSuperior.ColumnStyles.Add(New ColumnStyle(SizeType.Percent, 100.0F))
+
+        Dim panelFiltros As New FlowLayoutPanel() With {
+            .AutoSize = True,
+            .AutoSizeMode = AutoSizeMode.GrowAndShrink,
+            .Dock = DockStyle.Fill,
+            .FlowDirection = FlowDirection.LeftToRight,
+            .Margin = New Padding(0)
+        }
+        panelFiltros.Controls.Add(_rbPresentes)
+        panelFiltros.Controls.Add(_rbAusentes)
+
+        panelSuperior.Controls.Add(panelFiltros, 0, 0)
+        panelSuperior.Controls.Add(_lblEstado, 1, 0)
+
+        ConfigurarDataGridView(_dgvGrupos)
+        _dgvGrupos.AutoGenerateColumns = False
+        _dgvGrupos.MultiSelect = False
+        _dgvGrupos.SelectionMode = DataGridViewSelectionMode.FullRowSelect
+        _dgvGrupos.RowHeadersVisible = False
+        _dgvGrupos.DataSource = _bsGrupos
+        _dgvGrupos.Columns.Add(New DataGridViewTextBoxColumn() With {
+            .DataPropertyName = NameOf(PresenciaAgrupada.Grupo),
+            .HeaderText = EtiquetaGrupo,
+            .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
+        })
+        _dgvGrupos.Columns.Add(New DataGridViewTextBoxColumn() With {
+            .DataPropertyName = NameOf(PresenciaAgrupada.Cantidad),
+            .HeaderText = "Cantidad",
+            .AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells
+        })
+
+        ConfigurarDataGridView(_dgvFuncionarios)
+        _dgvFuncionarios.AutoGenerateColumns = False
+        _dgvFuncionarios.MultiSelect = False
+        _dgvFuncionarios.SelectionMode = DataGridViewSelectionMode.FullRowSelect
+        _dgvFuncionarios.RowHeadersVisible = False
+        _dgvFuncionarios.DataSource = _bsFuncionarios
+        _dgvFuncionarios.Columns.Add(New DataGridViewTextBoxColumn() With {
+            .DataPropertyName = NameOf(PresenciaFuncionarioDetalle.Nombre),
+            .HeaderText = "Funcionario",
+            .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
+        })
+        _dgvFuncionarios.Columns.Add(New DataGridViewTextBoxColumn() With {
+            .DataPropertyName = NameOf(PresenciaFuncionarioDetalle.Seccion),
+            .HeaderText = "Sección",
+            .AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells
+        })
+        _dgvFuncionarios.Columns.Add(New DataGridViewTextBoxColumn() With {
+            .DataPropertyName = NameOf(PresenciaFuncionarioDetalle.PuestoTrabajo),
+            .HeaderText = "Puesto de trabajo",
+            .AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells
+        })
+        _dgvFuncionarios.Columns.Add(New DataGridViewTextBoxColumn() With {
+            .DataPropertyName = NameOf(PresenciaFuncionarioDetalle.Estado),
+            .HeaderText = "Estado reportado",
+            .AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells
+        })
+
+        _splitContainer.Dock = DockStyle.Fill
+        _splitContainer.Orientation = Orientation.Vertical
+        _splitContainer.SplitterDistance = 280
+        _splitContainer.Panel1.Controls.Add(_dgvGrupos)
+        _splitContainer.Panel2.Controls.Add(_dgvFuncionarios)
+
+        Controls.Add(_splitContainer)
+        Controls.Add(panelSuperior)
+
+        Font = New Font("Segoe UI", 9.0F, FontStyle.Regular, GraphicsUnit.Point)
+        Text = TituloFormulario
+        MinimumSize = New Size(820, 540)
+        ClientSize = New Size(1024, 640)
+        StartPosition = FormStartPosition.CenterParent
+
+        AddHandler Load, AddressOf frmReportePresenciasBase_Load
+        AddHandler _rbPresentes.CheckedChanged, AddressOf Filtro_CheckedChanged
+        AddHandler _rbAusentes.CheckedChanged, AddressOf Filtro_CheckedChanged
+        AddHandler _bsGrupos.CurrentChanged, AddressOf bsGrupos_CurrentChanged
+        AddHandler _dgvGrupos.SelectionChanged, AddressOf dgvGrupos_SelectionChanged
+
+        _toolTip.SetToolTip(_rbAusentes, TooltipAusentes)
+
+        ResumeLayout(False)
+        PerformLayout()
+    End Sub
+
+    Private Sub ConfigurarDataGridView(grid As DataGridView)
+        With grid
+            .Dock = DockStyle.Fill
+            .ReadOnly = True
+            .AllowUserToAddRows = False
+            .AllowUserToDeleteRows = False
+            .AllowUserToResizeRows = False
+            .AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.None
+            .BackgroundColor = Color.White
+            .BorderStyle = BorderStyle.None
+        End With
+    End Sub
+
+    Private Async Sub frmReportePresenciasBase_Load(sender As Object, e As EventArgs)
+        Try
+            AppTheme.Aplicar(Me)
+        Catch
+        End Try
+
+        Await CargarDatosAsync()
+    End Sub
+
+    Private Async Sub Filtro_CheckedChanged(sender As Object, e As EventArgs)
+        Dim rb = TryCast(sender, RadioButton)
+        If rb Is Nothing OrElse Not rb.Checked Then Return
+        Await CargarDatosAsync()
+    End Sub
+
+    Private Async Function CargarDatosAsync() As Task
+        If _cargando Then Return
+
+        _cargando = True
+        Cursor = Cursors.WaitCursor
+        _rbPresentes.Enabled = False
+        _rbAusentes.Enabled = False
+        _lblEstado.Text = "Cargando datos..."
+        _lblEstado.ForeColor = SystemColors.GrayText
+
+        Try
+            Dim filtroSeleccionado = If(_rbPresentes.Checked, FiltroPresencia.Presentes, FiltroPresencia.Ausentes)
+            Dim fecha = ObtenerFechaConsulta()
+            Dim datos = Await _funcionarioService.ObtenerPresenciasAgrupadasAsync(fecha, filtroSeleccionado, Agrupacion)
+            If datos Is Nothing Then
+                datos = New List(Of PresenciaAgrupada)()
+            End If
+
+            _bsGrupos.DataSource = New BindingList(Of PresenciaAgrupada)(datos)
+
+            If _dgvGrupos.Rows.Count > 0 Then
+                _dgvGrupos.ClearSelection()
+                _dgvGrupos.Rows(0).Selected = True
+            End If
+
+            ActualizarDetalle()
+
+            Dim total = datos.Sum(Function(d) d.Cantidad)
+            If total > 0 Then
+                _lblEstado.Text = String.Format("{0} {1} el {2:d}", total, If(filtroSeleccionado = FiltroPresencia.Presentes, "presentes", "ausentes"), fecha)
+                _lblEstado.ForeColor = Color.FromArgb(33, 115, 70)
+            Else
+                _lblEstado.Text = "Sin datos para la selección actual."
+                _lblEstado.ForeColor = SystemColors.GrayText
+            End If
+        Catch ex As Exception
+            _lblEstado.Text = "Error al cargar datos: " & ex.Message
+            _lblEstado.ForeColor = Color.Firebrick
+            _bsGrupos.DataSource = New BindingList(Of PresenciaAgrupada)()
+            _bsFuncionarios.DataSource = New BindingList(Of PresenciaFuncionarioDetalle)()
+        Finally
+            _rbPresentes.Enabled = True
+            _rbAusentes.Enabled = True
+            Cursor = Cursors.Default
+            _cargando = False
+        End Try
+    End Function
+
+    Private Sub bsGrupos_CurrentChanged(sender As Object, e As EventArgs)
+        ActualizarDetalle()
+    End Sub
+
+    Private Sub dgvGrupos_SelectionChanged(sender As Object, e As EventArgs)
+        If _dgvGrupos.Focused AndAlso _dgvGrupos.CurrentRow IsNot Nothing Then
+            _bsGrupos.Position = _dgvGrupos.CurrentRow.Index
+        End If
+    End Sub
+
+    Private Sub ActualizarDetalle()
+        Dim seleccionado = TryCast(_bsGrupos.Current, PresenciaAgrupada)
+        If seleccionado Is Nothing Then
+            _bsFuncionarios.DataSource = New BindingList(Of PresenciaFuncionarioDetalle)()
+            Return
+        End If
+
+        _bsFuncionarios.DataSource = New BindingList(Of PresenciaFuncionarioDetalle)(seleccionado.Funcionarios)
+        If _dgvFuncionarios.Rows.Count > 0 Then
+            _dgvFuncionarios.ClearSelection()
+            _dgvFuncionarios.Rows(0).Selected = True
+        End If
+    End Sub
+End Class

--- a/Apex/UI/frmReportePresenciasPorPuestoTrabajo.vb
+++ b/Apex/UI/frmReportePresenciasPorPuestoTrabajo.vb
@@ -1,0 +1,30 @@
+Option Strict On
+Option Explicit On
+
+Public Class frmReportePresenciasPorPuestoTrabajo
+    Inherits frmReportePresenciasBase
+
+    Protected Overrides ReadOnly Property Agrupacion As AgrupacionPresencia
+        Get
+            Return AgrupacionPresencia.PuestoTrabajo
+        End Get
+    End Property
+
+    Protected Overrides ReadOnly Property TituloFormulario As String
+        Get
+            Return "Presentes/Ausentes por Puesto de Trabajo"
+        End Get
+    End Property
+
+    Protected Overrides ReadOnly Property EtiquetaGrupo As String
+        Get
+            Return "Puesto de trabajo"
+        End Get
+    End Property
+
+    Protected Overrides ReadOnly Property TooltipAusentes As String
+        Get
+            Return "Funcionarios activos sin presencia registrada en la fecha consultada (incluye francos, licencias y sin registro)."
+        End Get
+    End Property
+End Class

--- a/Apex/UI/frmReportePresenciasPorSeccion.vb
+++ b/Apex/UI/frmReportePresenciasPorSeccion.vb
@@ -1,0 +1,30 @@
+Option Strict On
+Option Explicit On
+
+Public Class frmReportePresenciasPorSeccion
+    Inherits frmReportePresenciasBase
+
+    Protected Overrides ReadOnly Property Agrupacion As AgrupacionPresencia
+        Get
+            Return AgrupacionPresencia.Seccion
+        End Get
+    End Property
+
+    Protected Overrides ReadOnly Property TituloFormulario As String
+        Get
+            Return "Presentes/Ausentes por Sección"
+        End Get
+    End Property
+
+    Protected Overrides ReadOnly Property EtiquetaGrupo As String
+        Get
+            Return "Sección"
+        End Get
+    End Property
+
+    Protected Overrides ReadOnly Property TooltipAusentes As String
+        Get
+            Return "Funcionarios activos sin presencia registrada en la fecha consultada (incluye francos, licencias y sin registro)."
+        End Get
+    End Property
+End Class

--- a/Apex/UI/frmReportes.Designer.vb
+++ b/Apex/UI/frmReportes.Designer.vb
@@ -34,6 +34,8 @@ Partial Class frmReportes
         Me.btnLicenciasPorTipo = New System.Windows.Forms.Button()
         Me.btnLicenciasPorEstado = New System.Windows.Forms.Button()
         Me.btnLicenciasTopFuncionarios = New System.Windows.Forms.Button()
+        Me.btnPresentesPorSeccion = New System.Windows.Forms.Button()
+        Me.btnPresentesPorPuesto = New System.Windows.Forms.Button()
         Me.FlowLayoutPanel1 = New System.Windows.Forms.FlowLayoutPanel()
         Me.FlowLayoutPanel1.SuspendLayout()
         Me.SuspendLayout()
@@ -173,6 +175,8 @@ Partial Class frmReportes
         Me.FlowLayoutPanel1.Controls.Add(Me.btnLicenciasPorTipo)
         Me.FlowLayoutPanel1.Controls.Add(Me.btnLicenciasPorEstado)
         Me.FlowLayoutPanel1.Controls.Add(Me.btnLicenciasTopFuncionarios)
+        Me.FlowLayoutPanel1.Controls.Add(Me.btnPresentesPorSeccion)
+        Me.FlowLayoutPanel1.Controls.Add(Me.btnPresentesPorPuesto)
         Me.FlowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill
         Me.FlowLayoutPanel1.FlowDirection = System.Windows.Forms.FlowDirection.TopDown
         Me.FlowLayoutPanel1.Location = New System.Drawing.Point(0, 0)
@@ -181,6 +185,26 @@ Partial Class frmReportes
         Me.FlowLayoutPanel1.Size = New System.Drawing.Size(717, 375)
         Me.FlowLayoutPanel1.TabIndex = 8
         Me.FlowLayoutPanel1.WrapContents = False
+        '
+        'btnPresentesPorSeccion
+        '
+        Me.btnPresentesPorSeccion.Location = New System.Drawing.Point(4, 545)
+        Me.btnPresentesPorSeccion.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.btnPresentesPorSeccion.Name = "btnPresentesPorSeccion"
+        Me.btnPresentesPorSeccion.Size = New System.Drawing.Size(330, 35)
+        Me.btnPresentesPorSeccion.TabIndex = 12
+        Me.btnPresentesPorSeccion.Text = "👥 Presentes por Sección"
+        Me.btnPresentesPorSeccion.UseVisualStyleBackColor = True
+        '
+        'btnPresentesPorPuesto
+        '
+        Me.btnPresentesPorPuesto.Location = New System.Drawing.Point(4, 590)
+        Me.btnPresentesPorPuesto.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
+        Me.btnPresentesPorPuesto.Name = "btnPresentesPorPuesto"
+        Me.btnPresentesPorPuesto.Size = New System.Drawing.Size(330, 35)
+        Me.btnPresentesPorPuesto.TabIndex = 13
+        Me.btnPresentesPorPuesto.Text = "🛠️ Presentes por Puesto"
+        Me.btnPresentesPorPuesto.UseVisualStyleBackColor = True
         '
         'frmReportes
         '
@@ -210,4 +234,6 @@ Partial Class frmReportes
     Friend WithEvents btnFuncionariosNivelEstudio As Button
     Friend WithEvents FlowLayoutPanel1 As FlowLayoutPanel
     Friend WithEvents btnResumenCantidades As Button
+    Friend WithEvents btnPresentesPorSeccion As Button
+    Friend WithEvents btnPresentesPorPuesto As Button
 End Class

--- a/Apex/UI/frmReportes.vb
+++ b/Apex/UI/frmReportes.vb
@@ -76,7 +76,9 @@ Public Class frmReportes
             btnFuncionariosNivelEstudio,
             btnLicenciasPorTipo,
             btnLicenciasPorEstado,
-            btnLicenciasTopFuncionarios
+            btnLicenciasTopFuncionarios,
+            btnPresentesPorSeccion,
+            btnPresentesPorPuesto
         }
 
         For i = 0 To botones.Length - 1
@@ -144,5 +146,13 @@ Public Class frmReportes
                 b.Height = 44
             End If
         Next
+    End Sub
+
+    Private Sub btnPresentesPorSeccion_Click(sender As Object, e As EventArgs) Handles btnPresentesPorSeccion.Click
+        AbrirFormularioReporte(Of frmReportePresenciasPorSeccion)()
+    End Sub
+
+    Private Sub btnPresentesPorPuesto_Click(sender As Object, e As EventArgs) Handles btnPresentesPorPuesto.Click
+        AbrirFormularioReporte(Of frmReportePresenciasPorPuestoTrabajo)()
     End Sub
 End Class


### PR DESCRIPTION
## Summary
- add service-layer support for grouping presences by section or job role and a reusable base form to toggle presentes vs ausentes
- expose new Presentes/Ausentes reports for sections and puestos within the reports dashboard

## Testing
- dotnet build Apex.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e013938a88832680971f4748e9d3c2