### PR TITLE
Adjust DataGridView column sizing in presence reports

### DIFF
--- a/Apex/UI/frmReportePresenciasBase.vb
+++ b/Apex/UI/frmReportePresenciasBase.vb
@@ -138,7 +138,7 @@ Public MustInherit Class frmReportePresenciasBase
         _dgvGrupos.Columns.Add(New DataGridViewTextBoxColumn() With {
             .DataPropertyName = NameOf(PresenciaAgrupada.Grupo),
             .HeaderText = EtiquetaGrupo,
-            .AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
+            .AutoSizeMode = DataGridViewAutoSizeColumnMode.DisplayedCells
         })
         _dgvGrupos.Columns.Add(New DataGridViewTextBoxColumn() With {
             .DataPropertyName = NameOf(PresenciaAgrupada.Cantidad),


### PR DESCRIPTION
## Summary
- switch the group column in the presence report grid to auto-size to displayed cells to avoid excessive width

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e01bb1df5c832689f8fdfe99f338ef