### PR TITLE
Add location and subdirection labels to employee search

### DIFF
--- a/Apex/UI/frmFuncionarioBuscar.Designer.vb
+++ b/Apex/UI/frmFuncionarioBuscar.Designer.vb
@@ -41,6 +41,8 @@ Partial Class frmFuncionarioBuscar
         Me.lblTipo = New System.Windows.Forms.Label()
         Me.lblFechaIngreso = New System.Windows.Forms.Label()
         Me.lblHorarioCompleto = New System.Windows.Forms.Label()
+        Me.lblUbicacion = New System.Windows.Forms.Label()
+        Me.lblSubDireccion = New System.Windows.Forms.Label()
         Me.lblCargo = New System.Windows.Forms.Label()
         Me.lblPresencia = New System.Windows.Forms.Label()
         Me.lblEstadoActividad = New System.Windows.Forms.Label()
@@ -231,6 +233,8 @@ Partial Class frmFuncionarioBuscar
         Me.flpDetalles.Controls.Add(Me.lblTipo)
         Me.flpDetalles.Controls.Add(Me.lblFechaIngreso)
         Me.flpDetalles.Controls.Add(Me.lblHorarioCompleto)
+        Me.flpDetalles.Controls.Add(Me.lblUbicacion)
+        Me.flpDetalles.Controls.Add(Me.lblSubDireccion)
         Me.flpDetalles.Controls.Add(Me.lblCargo)
         Me.flpDetalles.Controls.Add(Me.lblPresencia)
         Me.flpDetalles.Controls.Add(Me.lblEstadoActividad)
@@ -304,18 +308,44 @@ Partial Class frmFuncionarioBuscar
         Me.lblHorarioCompleto.TabIndex = 13
         Me.lblHorarioCompleto.Text = "Horario: -"
         '
+        'lblUbicacion
+        '
+        Me.lblUbicacion.Anchor = System.Windows.Forms.AnchorStyles.Left
+        Me.lblUbicacion.AutoSize = True
+        Me.lblUbicacion.Font = New System.Drawing.Font("Segoe UI", 9.5!)
+        Me.lblUbicacion.ForeColor = System.Drawing.Color.DimGray
+        Me.lblUbicacion.Location = New System.Drawing.Point(3, 171)
+        Me.lblUbicacion.Margin = New System.Windows.Forms.Padding(3, 0, 3, 2)
+        Me.lblUbicacion.Name = "lblUbicacion"
+        Me.lblUbicacion.Size = New System.Drawing.Size(325, 25)
+        Me.lblUbicacion.TabIndex = 23
+        Me.lblUbicacion.Text = "Ubicación: Seccion / Puesto de Trabajo"
+        '
+        'lblSubDireccion
+        '
+        Me.lblSubDireccion.Anchor = System.Windows.Forms.AnchorStyles.Left
+        Me.lblSubDireccion.AutoSize = True
+        Me.lblSubDireccion.Font = New System.Drawing.Font("Segoe UI", 9.5!)
+        Me.lblSubDireccion.ForeColor = System.Drawing.Color.DimGray
+        Me.lblSubDireccion.Location = New System.Drawing.Point(3, 198)
+        Me.lblSubDireccion.Margin = New System.Windows.Forms.Padding(3, 0, 3, 2)
+        Me.lblSubDireccion.Name = "lblSubDireccion"
+        Me.lblSubDireccion.Size = New System.Drawing.Size(152, 25)
+        Me.lblSubDireccion.TabIndex = 24
+        Me.lblSubDireccion.Text = "SubDireccion: -"
+        '
         'lblCargo
         '
         Me.lblCargo.Anchor = System.Windows.Forms.AnchorStyles.Left
         Me.lblCargo.AutoSize = True
         Me.lblCargo.Font = New System.Drawing.Font("Segoe UI", 9.5!)
         Me.lblCargo.ForeColor = System.Drawing.Color.DimGray
-        Me.lblCargo.Location = New System.Drawing.Point(3, 171)
+        Me.lblCargo.Location = New System.Drawing.Point(3, 225)
         Me.lblCargo.Margin = New System.Windows.Forms.Padding(3, 0, 3, 2)
         Me.lblCargo.Name = "lblCargo"
-        Me.lblCargo.Size = New System.Drawing.Size(80, 25)
+        Me.lblCargo.Size = New System.Drawing.Size(271, 25)
         Me.lblCargo.TabIndex = 4
-        Me.lblCargo.Text = "Cargo: -"
+        Me.lblCargo.Text = "Escalafon / SubEscalafon / Cargo: -"
         '
         'lblPresencia
         '
@@ -323,7 +353,7 @@ Partial Class frmFuncionarioBuscar
         Me.lblPresencia.AutoSize = True
         Me.lblPresencia.Font = New System.Drawing.Font("Segoe UI", 9.5!)
         Me.lblPresencia.ForeColor = System.Drawing.Color.DimGray
-        Me.lblPresencia.Location = New System.Drawing.Point(3, 198)
+        Me.lblPresencia.Location = New System.Drawing.Point(3, 252)
         Me.lblPresencia.Margin = New System.Windows.Forms.Padding(3, 0, 3, 2)
         Me.lblPresencia.Name = "lblPresencia"
         Me.lblPresencia.Size = New System.Drawing.Size(110, 25)
@@ -336,7 +366,7 @@ Partial Class frmFuncionarioBuscar
         Me.lblEstadoActividad.AutoSize = True
         Me.lblEstadoActividad.Font = New System.Drawing.Font("Segoe UI", 9.5!)
         Me.lblEstadoActividad.ForeColor = System.Drawing.Color.DimGray
-        Me.lblEstadoActividad.Location = New System.Drawing.Point(3, 225)
+        Me.lblEstadoActividad.Location = New System.Drawing.Point(3, 279)
         Me.lblEstadoActividad.Margin = New System.Windows.Forms.Padding(3, 0, 3, 2)
         Me.lblEstadoActividad.Name = "lblEstadoActividad"
         Me.lblEstadoActividad.Size = New System.Drawing.Size(85, 25)
@@ -347,7 +377,7 @@ Partial Class frmFuncionarioBuscar
         '
         Me.btnVerSituacion.Dock = System.Windows.Forms.DockStyle.Fill
         Me.btnVerSituacion.Font = New System.Drawing.Font("Segoe UI", 9.0!, System.Drawing.FontStyle.Bold)
-        Me.btnVerSituacion.Location = New System.Drawing.Point(3, 356)
+        Me.btnVerSituacion.Location = New System.Drawing.Point(3, 410)
         Me.btnVerSituacion.Name = "btnVerSituacion"
         Me.btnVerSituacion.Size = New System.Drawing.Size(371, 36)
         Me.btnVerSituacion.TabIndex = 17
@@ -484,6 +514,8 @@ Partial Class frmFuncionarioBuscar
     Friend WithEvents btnVerSituacion As Button
     Friend WithEvents lblFechaIngreso As Label
     Friend WithEvents lblCI As Label
+    Friend WithEvents lblUbicacion As Label
+    Friend WithEvents lblSubDireccion As Label
     Friend WithEvents lblCargo As Label
     Friend WithEvents lblPresencia As Label
     Friend WithEvents lblEstadoActividad As Label

--- a/Apex/UI/frmFuncionarioBuscar.vb
+++ b/Apex/UI/frmFuncionarioBuscar.vb
@@ -897,10 +897,15 @@ Public Class frmFuncionarioBuscar
             Dim f = Await uow.Repository(Of Funcionario)() _
             .GetAll() _
             .Include(Function(x) x.Cargo) _
+            .Include(Function(x) x.Escalafon) _
+            .Include(Function(x) x.SubEscalafon) _
             .Include(Function(x) x.TipoFuncionario) _
             .Include(Function(x) x.Semana) _
             .Include(Function(x) x.Turno) _
             .Include(Function(x) x.Horario) _
+            .Include(Function(x) x.Seccion) _
+            .Include(Function(x) x.PuestoTrabajo) _
+            .Include(Function(x) x.SubDireccion) _
             .AsNoTracking() _
             .FirstOrDefaultAsync(Function(x) x.Id = id)
 
@@ -916,10 +921,15 @@ Public Class frmFuncionarioBuscar
             ' Concatenamos el texto fijo con el valor
             lblCI.Text = "CI: " & f.CI
             lblNombreCompleto.Text = f.Nombre ' El nombre principal no lleva etiqueta
-            lblCargo.Text = "Cargo: " & If(f.Cargo Is Nothing, "-", f.Cargo.Nombre)
+            Dim escalafonNombre = If(f.Escalafon IsNot Nothing, f.Escalafon.Nombre, "-")
+            Dim subEscalafonNombre = If(f.SubEscalafon IsNot Nothing, f.SubEscalafon.Nombre, "-")
+            Dim cargoNombre = If(f.Cargo IsNot Nothing, f.Cargo.Nombre, "-")
+            lblCargo.Text = $"Escalafon / SubEscalafon / Cargo: {escalafonNombre} / {subEscalafonNombre} / {cargoNombre}"
             lblTipo.Text = "Tipo: " & f.TipoFuncionario.Nombre
             lblFechaIngreso.Text = "Fecha Ingreso: " & f.FechaIngreso.ToShortDateString()
             lblHorarioCompleto.Text = $"Horario: {If(f.Semana IsNot Nothing, f.Semana.Nombre, "-")} / {If(f.Turno IsNot Nothing, f.Turno.Nombre, "-")} / {If(f.Horario IsNot Nothing, f.Horario.Nombre, "-")}"
+            lblUbicacion.Text = $"Ubicación: {If(f.Seccion IsNot Nothing, f.Seccion.Nombre, "-")} / {If(f.PuestoTrabajo Is Not Nothing, f.PuestoTrabajo.Nombre, "-")}"
+            lblSubDireccion.Text = "SubDireccion: " & If(f.SubDireccion IsNot Nothing, f.SubDireccion.Nombre, "-")
 
             ' El estado ya estaba correcto, lo mantenemos igual
             If f.Activo Then
@@ -1300,13 +1310,15 @@ Public Class frmFuncionarioBuscar
     Private Sub LimpiarDetalle()
         lblCI.Text = "CI: -"
         lblNombreCompleto.Text = "Seleccione un funcionario"
-        lblCargo.Text = "Cargo: -"
+        lblCargo.Text = "Escalafon / SubEscalafon / Cargo: - / - / -"
         lblTipo.Text = "Tipo: -"
         lblFechaIngreso.Text = "Fecha Ingreso: -"
         lblEstadoActividad.Text = "Estado: -"
         lblPresencia.Text = ""
         pbFotoDetalle.Image = Nothing
         lblHorarioCompleto.Text = "Horario: -"
+        lblUbicacion.Text = "Ubicación: Seccion / Puesto de Trabajo"
+        lblSubDireccion.Text = "SubDireccion: -"
         _detallesEstadoActual.Clear()
 
         ' Oculta los botones de acción y el panel de detalle.


### PR DESCRIPTION
## Summary
- add new labels to the funcionario detail panel for ubicación and subdirección
- update the cargo label text to show escalafón, subescalafón, and cargo hierarchy
- populate the new labels with data from the funcionario record and refresh their defaults when clearing the view

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0220e3d908326a99f80f18d7e785b