### PR TITLE
Ensure viáticos report definition loads reliably

### DIFF
--- a/Apex/UI/frmViaticosRPT.vb
+++ b/Apex/UI/frmViaticosRPT.vb
@@ -26,16 +26,26 @@ Public Class frmViaticosRPT
         Me.Cursor = Cursors.WaitCursor
 
         Try
+            ReportViewer1.Reset()
             ReportViewer1.ProcessingMode = ProcessingMode.Local
             ReportViewer1.LocalReport.DataSources.Clear()
 
-            ReportResourceLoader.LoadLocalReportDefinition(
+            Dim definicion = ReportResourceLoader.LoadLocalReportDefinition(
                 ReportViewer1.LocalReport,
                 GetType(frmViaticosRPT),
                 "Apex.Reportes.ViaticosListado.rdlc",
                 "ViaticosListado.rdlc",
                 New String() {"..\\..\\Reportes\\ViaticosListado.rdlc"}
             )
+
+            Select Case definicion.Source
+                Case ReportDefinitionSource.Embedded
+                    ReportViewer1.LocalReport.ReportEmbeddedResource = definicion.ResourceName
+                    ReportViewer1.LocalReport.ReportPath = Nothing
+                Case ReportDefinitionSource.File
+                    ReportViewer1.LocalReport.ReportPath = definicion.FilePath
+                    ReportViewer1.LocalReport.ReportEmbeddedResource = Nothing
+            End Select
 
             ReportViewer1.LocalReport.DataSources.Add(New ReportDataSource("DataSetViaticos", _datos))
 


### PR DESCRIPTION
## Summary
- reset the report viewer before configuring the viáticos listing report
- load the RDLC definition with fallbacks and explicitly set the source on the report viewer to avoid missing definition errors

## Testing
- not run (not supported in container)

------
https://chatgpt.com/codex/tasks/task_e_68e0a88b50308326a98974c9bd967de2