### PR TITLE
Fix string splitting with ControlChars under Option Strict

### DIFF
--- a/Apex/Helpers/ConsultasGenericas.vb
+++ b/Apex/Helpers/ConsultasGenericas.vb
@@ -771,7 +771,9 @@ Public Module ConsultasGenericas
         If String.IsNullOrWhiteSpace(funcionariosCadena) Then
             Return 0
         End If
-        Dim tokens = funcionariosCadena.Split(New Char() {","c, ";"c, ControlChars.Lf, ControlChars.Cr, "|"c}, StringSplitOptions.RemoveEmptyEntries)
+        Dim separadores = New String() {",", ";", ControlChars.Lf, ControlChars.Cr, "|", Environment.NewLine}
+
+        Dim tokens = funcionariosCadena.Split(separadores, StringSplitOptions.RemoveEmptyEntries)
         Return tokens.Select(Function(t) t.Trim()).Count(Function(t) Not String.IsNullOrWhiteSpace(t))
     End Function
 

--- a/Apex/Services/NotificacionService.vb
+++ b/Apex/Services/NotificacionService.vb
@@ -129,7 +129,9 @@ Public Class NotificacionService
         End If
 
         If Not String.IsNullOrWhiteSpace(funcionarioFiltro) Then
-            Dim terminos = funcionarioFiltro.Split({" "c, vbTab, ControlChars.Lf, ControlChars.Cr}, StringSplitOptions.RemoveEmptyEntries).
+            Dim separadores = New String() {" ", vbTab, ControlChars.Lf, ControlChars.Cr, Environment.NewLine}
+
+            Dim terminos = funcionarioFiltro.Split(separadores, StringSplitOptions.RemoveEmptyEntries).
                 Select(Function(t) t.Trim()).
                 Where(Function(t) t.Length > 0).
                 ToArray()

--- a/Apex/UI/frmFiltros.vb
+++ b/Apex/UI/frmFiltros.vb
@@ -609,8 +609,18 @@ Partial Public Class frmFiltros
         If String.IsNullOrWhiteSpace(input) Then Return Enumerable.Empty(Of String)()
 
         ' separadores comunes
-        Dim trozos = input.Split(New Char() {";"c, ","c, "/"c, " "c, ControlChars.Cr, ControlChars.Lf, ControlChars.Tab},
-                             StringSplitOptions.RemoveEmptyEntries)
+        Dim separadores = New String() {
+            ";",
+            ",",
+            "/",
+            " ",
+            ControlChars.Cr,
+            ControlChars.Lf,
+            ControlChars.Tab,
+            Environment.NewLine
+        }
+
+        Dim trozos = input.Split(separadores, StringSplitOptions.RemoveEmptyEntries)
 
         Dim list As New List(Of String)
         For Each t In trozos


### PR DESCRIPTION
## Summary
- replace character separator arrays with string-based arrays where ControlChars constants are used
- ensure filter, notification, and generic helper splitting works under Option Strict without implicit conversions

## Testing
- not run (build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0b9a474fc8326b52ee26c37579195