### PR TITLE
Fix viaticos report viewer binding

### DIFF
--- a/Apex/UI/frmViaticosListas.vb
+++ b/Apex/UI/frmViaticosListas.vb
@@ -125,7 +125,7 @@ Public Class frmViaticosListas
             Return
         End If
 
-        Dim dtReporte As DataTable
+        Dim dtReporte As DataTable = Nothing
         Dim vista = TryCast(_bsViaticos.List, DataView)
 
         If vista IsNot Nothing Then
@@ -141,10 +141,6 @@ Public Class frmViaticosListas
             Notifier.Info(Me, "No hay datos para mostrar en el informe.")
             Return
         End If
-
-        ' --- LÍNEA DE DIAGNÓSTICO AÑADIDA ---
-        ' Esta línea es crucial. Nos dirá cuántas filas se están enviando.
-        MessageBox.Show($"Se enviarán {dtReporte.Rows.Count} filas al informe.", "Diagnóstico de Reporte")
 
         Using visor As New frmViaticosRPT(dtpPeriodo.Value, dtReporte)
             visor.ShowDialog(Me)

--- a/Apex/UI/frmViaticosRPT.vb
+++ b/Apex/UI/frmViaticosRPT.vb
@@ -32,7 +32,7 @@ Public Class frmViaticosRPT
             ReportViewer1.ProcessingMode = ProcessingMode.Local
             ReportViewer1.LocalReport.DataSources.Clear()
 
-            Dim nombreRecursoCorrecto As String = "Apex.ViaticosListado.rdlc"
+            Dim nombreRecursoCorrecto As String = "Apex.Reportes.ViaticosListado.rdlc"
 
             Dim definicion = ReportResourceLoader.LoadLocalReportDefinition(
                 ReportViewer1.LocalReport,


### PR DESCRIPTION
## Summary
- initialize the report DataTable before copying data and remove debug message boxes
- point the viáticos report viewer to the correct embedded report resource

## Testing
- not run (Windows-only .NET Framework project)


------
https://chatgpt.com/codex/tasks/task_e_68e0beb3607883268924c479583fd325