### PR TITLE
Fix viaticos report parameter layout

### DIFF
--- a/Apex/Reportes/ViaticosListado.rdlc
+++ b/Apex/Reportes/ViaticosListado.rdlc
@@ -710,9 +710,29 @@
   </ReportParameters>
   <ReportParametersLayout>
     <GridLayoutDefinition>
-      <NumberOfColumns>4</NumberOfColumns>
-      <NumberOfRows>2</NumberOfRows>
+      <NumberOfColumns>3</NumberOfColumns>
+      <NumberOfRows>1</NumberOfRows>
     </GridLayoutDefinition>
+    <ParameterLayout>
+      <GridLayoutCell ParameterName="Titulo">
+        <ColumnIndex>0</ColumnIndex>
+        <RowIndex>0</RowIndex>
+        <ColumnSpan>1</ColumnSpan>
+        <RowSpan>1</RowSpan>
+      </GridLayoutCell>
+      <GridLayoutCell ParameterName="Periodo">
+        <ColumnIndex>1</ColumnIndex>
+        <RowIndex>0</RowIndex>
+        <ColumnSpan>1</ColumnSpan>
+        <RowSpan>1</RowSpan>
+      </GridLayoutCell>
+      <GridLayoutCell ParameterName="TotalRegistros">
+        <ColumnIndex>2</ColumnIndex>
+        <RowIndex>0</RowIndex>
+        <ColumnSpan>1</ColumnSpan>
+        <RowSpan>1</RowSpan>
+      </GridLayoutCell>
+    </ParameterLayout>
   </ReportParametersLayout>
   <Language>es-UY</Language>
   <rd:ReportUnitType>Inch</rd:ReportUnitType>


### PR DESCRIPTION
## Summary
- align the ViaticosListado report parameter layout with the defined report parameters to avoid invalid definition errors when loading the report viewer

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0bfaa87148326a5a81ff2b2398997