### PR TITLE
Adjust viaticos report width to avoid blank pages

### DIFF
--- a/Apex/Reportes/ViaticosListado.rdlc
+++ b/Apex/Reportes/ViaticosListado.rdlc
@@ -681,7 +681,7 @@
 				<Height>2.7in</Height>
 				<Style />
 			</Body>
-			<Width>11in</Width>
+                        <Width>9.5in</Width>
 			<Page>
 				<PageHeight>8.5in</PageHeight>
 				<PageWidth>11in</PageWidth>


### PR DESCRIPTION
## Summary
- reduce the body width in ViaticosListado.rdlc so it stays within the printable area and no longer inserts blank pages between records

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e115bef6a48326b97b98d78a1cb07c