### PR TITLE
Refactor configuracion catalogs for extensibility

### DIFF
--- a/Apex/UI/frmConfiguracion.Designer.vb
+++ b/Apex/UI/frmConfiguracion.Designer.vb
@@ -22,137 +22,16 @@ Partial Class frmConfiguracion
     'Do not modify it using the code editor.
     <System.Diagnostics.DebuggerStepThrough()>
     Private Sub InitializeComponent()
-        Me.btnTurnos = New System.Windows.Forms.Button()
-        Me.btnAreasTrabajo = New System.Windows.Forms.Button()
-        Me.btnSecciones = New System.Windows.Forms.Button()
-        Me.btnCargos = New System.Windows.Forms.Button()
-        Me.btnGestionarIncidencias = New System.Windows.Forms.Button()
         Me.FlowLayoutPanel1 = New System.Windows.Forms.FlowLayoutPanel()
-        Me.btnSubDirecciones = New System.Windows.Forms.Button()
-        Me.btnUnidadesGenerales = New System.Windows.Forms.Button()
-        Me.btnNomenclaturas = New System.Windows.Forms.Button()
-        Me.btnEscalafones = New System.Windows.Forms.Button()
-        Me.btnFunciones = New System.Windows.Forms.Button()
-        Me.FlowLayoutPanel1.SuspendLayout()
         Me.SuspendLayout()
-        '
-        'btnTurnos
-        '
-        Me.btnTurnos.Location = New System.Drawing.Point(297, 50)
-        Me.btnTurnos.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.btnTurnos.Name = "btnTurnos"
-        Me.btnTurnos.Size = New System.Drawing.Size(285, 35)
-        Me.btnTurnos.TabIndex = 3
-        Me.btnTurnos.Text = "Gestionar Turnos"
-        Me.btnTurnos.UseVisualStyleBackColor = True
-        '
-        'btnAreasTrabajo
-        '
-        Me.btnAreasTrabajo.Location = New System.Drawing.Point(4, 50)
-        Me.btnAreasTrabajo.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.btnAreasTrabajo.Name = "btnAreasTrabajo"
-        Me.btnAreasTrabajo.Size = New System.Drawing.Size(285, 35)
-        Me.btnAreasTrabajo.TabIndex = 2
-        Me.btnAreasTrabajo.Text = "Gestionar Áreas de Trabajo"
-        Me.btnAreasTrabajo.UseVisualStyleBackColor = True
-        '
-        'btnSecciones
-        '
-        Me.btnSecciones.Location = New System.Drawing.Point(297, 5)
-        Me.btnSecciones.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.btnSecciones.Name = "btnSecciones"
-        Me.btnSecciones.Size = New System.Drawing.Size(285, 35)
-        Me.btnSecciones.TabIndex = 1
-        Me.btnSecciones.Text = "Gestionar Secciones"
-        Me.btnSecciones.UseVisualStyleBackColor = True
-        '
-        'btnCargos
-        '
-        Me.btnCargos.Location = New System.Drawing.Point(4, 5)
-        Me.btnCargos.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.btnCargos.Name = "btnCargos"
-        Me.btnCargos.Size = New System.Drawing.Size(285, 35)
-        Me.btnCargos.TabIndex = 0
-        Me.btnCargos.Text = "Gestionar Cargos"
-        Me.btnCargos.UseVisualStyleBackColor = True
-        '
-        'btnGestionarIncidencias
-        '
-        Me.btnGestionarIncidencias.Location = New System.Drawing.Point(4, 95)
-        Me.btnGestionarIncidencias.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.btnGestionarIncidencias.Name = "btnGestionarIncidencias"
-        Me.btnGestionarIncidencias.Size = New System.Drawing.Size(285, 35)
-        Me.btnGestionarIncidencias.TabIndex = 5
-        Me.btnGestionarIncidencias.Text = "Gestionar Incidencias"
-        Me.btnGestionarIncidencias.UseVisualStyleBackColor = True
         '
         'FlowLayoutPanel1
         '
-        Me.FlowLayoutPanel1.Controls.Add(Me.btnCargos)
-        Me.FlowLayoutPanel1.Controls.Add(Me.btnSecciones)
-        Me.FlowLayoutPanel1.Controls.Add(Me.btnAreasTrabajo)
-        Me.FlowLayoutPanel1.Controls.Add(Me.btnTurnos)
-        Me.FlowLayoutPanel1.Controls.Add(Me.btnGestionarIncidencias)
-        Me.FlowLayoutPanel1.Controls.Add(Me.btnSubDirecciones)
-        Me.FlowLayoutPanel1.Controls.Add(Me.btnUnidadesGenerales)
-        Me.FlowLayoutPanel1.Controls.Add(Me.btnNomenclaturas)
-        Me.FlowLayoutPanel1.Controls.Add(Me.btnEscalafones)
-        Me.FlowLayoutPanel1.Controls.Add(Me.btnFunciones)
         Me.FlowLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill
         Me.FlowLayoutPanel1.Location = New System.Drawing.Point(0, 0)
         Me.FlowLayoutPanel1.Name = "FlowLayoutPanel1"
         Me.FlowLayoutPanel1.Size = New System.Drawing.Size(717, 375)
-        Me.FlowLayoutPanel1.TabIndex = 8
-        '
-        'btnSubDirecciones
-        '
-        Me.btnSubDirecciones.Location = New System.Drawing.Point(297, 95)
-        Me.btnSubDirecciones.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.btnSubDirecciones.Name = "btnSubDirecciones"
-        Me.btnSubDirecciones.Size = New System.Drawing.Size(285, 35)
-        Me.btnSubDirecciones.TabIndex = 9
-        Me.btnSubDirecciones.Text = "Gestionar Subdirecciones"
-        Me.btnSubDirecciones.UseVisualStyleBackColor = True
-        '
-        'btnUnidadesGenerales
-        '
-        Me.btnUnidadesGenerales.Location = New System.Drawing.Point(4, 140)
-        Me.btnUnidadesGenerales.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.btnUnidadesGenerales.Name = "btnUnidadesGenerales"
-        Me.btnUnidadesGenerales.Size = New System.Drawing.Size(285, 35)
-        Me.btnUnidadesGenerales.TabIndex = 12
-        Me.btnUnidadesGenerales.Text = "Gestionar Unidades Generales"
-        Me.btnUnidadesGenerales.UseVisualStyleBackColor = True
-        '
-        'btnNomenclaturas
-        '
-        Me.btnNomenclaturas.Location = New System.Drawing.Point(297, 140)
-        Me.btnNomenclaturas.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.btnNomenclaturas.Name = "btnNomenclaturas"
-        Me.btnNomenclaturas.Size = New System.Drawing.Size(285, 35)
-        Me.btnNomenclaturas.TabIndex = 8
-        Me.btnNomenclaturas.Text = "Nomenclaturas"
-        Me.btnNomenclaturas.UseVisualStyleBackColor = True
-        '
-        'btnEscalafones
-        '
-        Me.btnEscalafones.Location = New System.Drawing.Point(4, 185)
-        Me.btnEscalafones.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.btnEscalafones.Name = "btnEscalafones"
-        Me.btnEscalafones.Size = New System.Drawing.Size(285, 35)
-        Me.btnEscalafones.TabIndex = 10
-        Me.btnEscalafones.Text = "Gestionar Escalafones"
-        Me.btnEscalafones.UseVisualStyleBackColor = True
-        '
-        'btnFunciones
-        '
-        Me.btnFunciones.Location = New System.Drawing.Point(297, 185)
-        Me.btnFunciones.Margin = New System.Windows.Forms.Padding(4, 5, 4, 5)
-        Me.btnFunciones.Name = "btnFunciones"
-        Me.btnFunciones.Size = New System.Drawing.Size(285, 35)
-        Me.btnFunciones.TabIndex = 11
-        Me.btnFunciones.Text = "Gestionar Funciones"
-        Me.btnFunciones.UseVisualStyleBackColor = True
+        Me.FlowLayoutPanel1.TabIndex = 0
         '
         'frmConfiguracion
         '
@@ -165,19 +44,8 @@ Partial Class frmConfiguracion
         Me.Name = "frmConfiguracion"
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent
         Me.Text = "Configuración del Sistema"
-        Me.FlowLayoutPanel1.ResumeLayout(False)
         Me.ResumeLayout(False)
 
     End Sub
-    Friend WithEvents btnTurnos As Button
-    Friend WithEvents btnAreasTrabajo As Button
-    Friend WithEvents btnSecciones As Button
-    Friend WithEvents btnCargos As Button
-    Friend WithEvents btnGestionarIncidencias As Button
     Friend WithEvents FlowLayoutPanel1 As FlowLayoutPanel
-    Friend WithEvents btnSubDirecciones As Button
-    Friend WithEvents btnUnidadesGenerales As Button
-    Friend WithEvents btnNomenclaturas As Button
-    Friend WithEvents btnEscalafones As Button
-    Friend WithEvents btnFunciones As Button
 End Class

--- a/Apex/UI/frmConfiguracion.vb
+++ b/Apex/UI/frmConfiguracion.vb
@@ -1,9 +1,98 @@
-﻿Public Class frmConfiguracion
+Imports System.Linq
+
+Public Class frmConfiguracion
+
+    Private Shared ReadOnly CatalogosPredeterminados As CatalogoConfiguracion() = {
+        New CatalogoConfiguracion("Gestionar Cargos", GetType(frmGrados), 10),
+        New CatalogoConfiguracion("Gestionar Secciones", GetType(frmSecciones), 20),
+        New CatalogoConfiguracion("Gestionar Áreas de Trabajo", GetType(frmAreaTrabajoCategorias), 30),
+        New CatalogoConfiguracion("Gestionar Turnos", GetType(frmTurnos), 40),
+        New CatalogoConfiguracion("Gestionar Incidencias", GetType(frmIncidencias), 50),
+        New CatalogoConfiguracion("Gestionar Subdirecciones", GetType(frmSubDirecciones), 60),
+        New CatalogoConfiguracion("Gestionar Unidades Generales", GetType(frmUnidadesGenerales), 70),
+        New CatalogoConfiguracion("Nomenclaturas", GetType(frmNomenclaturas), 80),
+        New CatalogoConfiguracion("Gestionar Escalafones", GetType(frmEscalafones), 90),
+        New CatalogoConfiguracion("Gestionar Funciones", GetType(frmFunciones), 100)
+    }
+
+    Private Shared ReadOnly CatalogosExtras As New List(Of CatalogoConfiguracion)
 
     Private Sub frmConfiguracion_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         AppTheme.Aplicar(Me)
         ConfigurarLayoutConfiguracion()
+        ConstruirCatalogos()
     End Sub
+
+    ''' <summary>
+    ''' Permite registrar catálogos adicionales antes de mostrar el formulario.
+    ''' </summary>
+    ''' <param name="texto">Texto visible en el botón.</param>
+    ''' <param name="formulario">Formulario que se abrirá al hacer clic.</param>
+    ''' <param name="orden">Orden opcional para posicionar el botón (se ordena ascendente).</param>
+    Public Shared Sub RegistrarCatalogo(texto As String, formulario As Type, Optional orden As Integer? = Nothing)
+        If String.IsNullOrWhiteSpace(texto) Then Throw New ArgumentException("El texto del catálogo no puede estar vacío.", NameOf(texto))
+        If formulario Is Nothing Then Throw New ArgumentNullException(NameOf(formulario))
+        If Not GetType(Form).IsAssignableFrom(formulario) Then
+            Throw New ArgumentException("El tipo indicado debe heredar de Form.", NameOf(formulario))
+        End If
+
+        Dim nuevoCatalogo As New CatalogoConfiguracion(texto.Trim(), formulario, orden.GetValueOrDefault(CalcularOrdenSugerido()))
+
+        SyncLock CatalogosExtras
+            CatalogosExtras.Add(nuevoCatalogo)
+        End SyncLock
+    End Sub
+
+    Private Shared Function CalcularOrdenSugerido() As Integer
+        Dim baseOrden = CatalogosPredeterminados.Length * 10
+        Dim extrasCount As Integer
+        SyncLock CatalogosExtras
+            extrasCount = CatalogosExtras.Count
+        End SyncLock
+        Return baseOrden + ((extrasCount + 1) * 10)
+    End Function
+
+    Private Sub ConstruirCatalogos()
+        Dim catalogos As List(Of CatalogoConfiguracion) = ObtenerCatalogos().OrderBy(Function(c) c.Orden).ThenBy(Function(c) c.Texto).ToList()
+
+        FlowLayoutPanel1.SuspendLayout()
+        FlowLayoutPanel1.Controls.Clear()
+
+        For i = 0 To catalogos.Count - 1
+            Dim catalogo = catalogos(i)
+            Dim boton = CrearBotonCatalogo(catalogo, i)
+            FlowLayoutPanel1.Controls.Add(boton)
+        Next
+
+        FlowLayoutPanel1.ResumeLayout()
+        AjustarAnchoBotones(Nothing, EventArgs.Empty)
+    End Sub
+
+    Private Shared Function ObtenerCatalogos() As IEnumerable(Of CatalogoConfiguracion)
+        Dim extras As CatalogoConfiguracion()
+        SyncLock CatalogosExtras
+            extras = CatalogosExtras.ToArray()
+        End SyncLock
+
+        Return CatalogosPredeterminados.Concat(extras)
+    End Function
+
+    Private Function CrearBotonCatalogo(catalogo As CatalogoConfiguracion, tabIndex As Integer) As Button
+        Dim boton As New Button() With {
+            .AutoSize = False,
+            .Height = 44,
+            .MinimumSize = New Size(220, 44),
+            .Margin = New Padding(12),
+            .FlatStyle = FlatStyle.Standard,
+            .TextAlign = ContentAlignment.MiddleCenter,
+            .TabIndex = tabIndex,
+            .Text = catalogo.Texto,
+            .Tag = catalogo
+        }
+        AddHandler boton.Click, AddressOf Catalogo_Click
+        Return boton
+    End Function
+
     ' Llamar después de InitializeComponent()
     Public Sub ConfigurarLayoutConfiguracion()
         ' ---- FlowLayout general
@@ -15,24 +104,6 @@
             .Padding = New Padding(12)
             .Margin = New Padding(0)
         End With
-
-        ' ---- Normalizar botones (texto, tamaño mínimo, márgenes)
-        Dim botones() As Button = {
-        btnCargos, btnSecciones, btnAreasTrabajo, btnTurnos,
-        btnGestionarIncidencias, btnSubDirecciones, btnUnidadesGenerales, btnNomenclaturas, btnEscalafones,
-        btnFunciones
-    }
-
-        For i = 0 To botones.Length - 1
-            Dim b = botones(i)
-            b.AutoSize = False
-            b.Height = 44
-            b.MinimumSize = New Size(220, 44)
-            b.Margin = New Padding(12)
-            b.FlatStyle = FlatStyle.Standard
-            b.TextAlign = ContentAlignment.MiddleCenter
-            b.TabIndex = i
-        Next
 
         ' Ajuste responsivo de ancho (1/2/3 columnas según espacio)
         AddHandler FlowLayoutPanel1.Resize, AddressOf AjustarAnchoBotones
@@ -59,64 +130,46 @@
 
         For Each c In pnl.Controls
             Dim b = TryCast(c, Button)
-            If b IsNot Nothing Then
+            If b Is Not Nothing Then
                 b.Width = anchoBtn
                 b.Height = 44
             End If
         Next
     End Sub
 
+    Private Sub Catalogo_Click(sender As Object, e As EventArgs)
+        Dim boton = TryCast(sender, Button)
+        Dim catalogo = TryCast(boton?.Tag, CatalogoConfiguracion)
+        If catalogo Is Nothing Then Return
+
+        AbrirHijoEnDashboard(catalogo.Formulario)
+    End Sub
+
     ' === Helper local para abrir hijos en el Dashboard (usando la pila) ===
-    Private Sub AbrirHijoEnDashboard(Of T As {Form, New})()
+    Private Sub AbrirHijoEnDashboard(formType As Type)
         Dim dash = Application.OpenForms.OfType(Of frmDashboard)().FirstOrDefault()
         If dash Is Nothing Then
             MessageBox.Show("No se encontró el Dashboard activo.", "Navegación", MessageBoxButtons.OK, MessageBoxIcon.Warning)
             Return
         End If
         ' Creamos una instancia fresca del hijo y lo abrimos como “child”.
-        dash.AbrirChild(New T())
+        Dim child = TryCast(Activator.CreateInstance(formType), Form)
+        If child Is Nothing Then
+            MessageBox.Show("No se pudo crear el formulario solicitado.", "Navegación", MessageBoxButtons.OK, MessageBoxIcon.Error)
+            Return
+        End If
+        dash.AbrirChild(child)
     End Sub
 
-    Private Sub btnGestionarIncidencias_Click(sender As Object, e As EventArgs) Handles btnGestionarIncidencias.Click
-        AbrirHijoEnDashboard(Of frmIncidencias)()
-    End Sub
+    Private Class CatalogoConfiguracion
+        Public Sub New(texto As String, formulario As Type, orden As Integer)
+            Me.Texto = texto
+            Me.Formulario = formulario
+            Me.Orden = orden
+        End Sub
 
-    Private Sub btnCargos_Click(sender As Object, e As EventArgs) Handles btnCargos.Click
-        AbrirHijoEnDashboard(Of frmGrados)()
-    End Sub
-
-    Private Sub btnSecciones_Click(sender As Object, e As EventArgs) Handles btnSecciones.Click
-        AbrirHijoEnDashboard(Of frmSecciones)()
-    End Sub
-
-    Private Sub btnAreasTrabajo_Click(sender As Object, e As EventArgs) Handles btnAreasTrabajo.Click
-        AbrirHijoEnDashboard(Of frmAreaTrabajoCategorias)()
-    End Sub
-
-    Private Sub btnTurnos_Click(sender As Object, e As EventArgs) Handles btnTurnos.Click
-        AbrirHijoEnDashboard(Of frmTurnos)()
-    End Sub
-
-    Private Sub btnNomenclaturas_Click(sender As Object, e As EventArgs) Handles btnNomenclaturas.Click
-        ' Antes: abrías y cerrabas este formulario.
-        ' Ahora: lo abrimos como “child”; este queda oculto y se restaura al cerrar el hijo.
-        AbrirHijoEnDashboard(Of frmNomenclaturas)()
-    End Sub
-
-    Private Sub btnSubDirecciones_Click(sender As Object, e As EventArgs) Handles btnSubDirecciones.Click
-        AbrirHijoEnDashboard(Of frmSubDirecciones)()
-    End Sub
-
-    Private Sub btnUnidadesGenerales_Click(sender As Object, e As EventArgs) Handles btnUnidadesGenerales.Click
-        AbrirHijoEnDashboard(Of frmUnidadesGenerales)()
-    End Sub
-
-    Private Sub btnEscalafones_Click(sender As Object, e As EventArgs) Handles btnEscalafones.Click
-        AbrirHijoEnDashboard(Of frmEscalafones)()
-    End Sub
-
-    Private Sub btnFunciones_Click(sender As Object, e As EventArgs) Handles btnFunciones.Click
-        AbrirHijoEnDashboard(Of frmFunciones)()
-    End Sub
-
+        Public ReadOnly Property Texto As String
+        Public ReadOnly Property Formulario As Type
+        Public ReadOnly Property Orden As Integer
+    End Class
 End Class


### PR DESCRIPTION
## Summary
- simplify frmConfiguracion designer so only the flow layout container remains
- build configuration catalog buttons dynamically from a shared registry with default entries
- provide a registration API so external modules can add more catalog shortcuts without modifying the form

## Testing
- attempted `dotnet build Apex/Apex.vbproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e11786f7e8832683951874375cb01d