### PR TITLE
Fix frmResumenCantidades layout handler for designer

### DIFF
--- a/Apex/UI/frmResumenCantidades.vb
+++ b/Apex/UI/frmResumenCantidades.vb
@@ -98,11 +98,7 @@ Public Class frmResumenCantidades
         _panelHeader.Controls.Add(_btnActualizar)
         _panelHeader.Controls.Add(_lblUltimaActualizacion)
 
-        AddHandler _panelHeader.Layout, Sub(sender, args)
-                                            _dtpFecha.Location = New Point(0, (_panelHeader.Height - _dtpFecha.Height) \ 2)
-                                            _btnActualizar.Location = New Point(_dtpFecha.Right + 16, (_panelHeader.Height - _btnActualizar.Height) \ 2)
-                                            _lblUltimaActualizacion.Location = New Point(_panelHeader.Width - _lblUltimaActualizacion.Width, (_panelHeader.Height - _lblUltimaActualizacion.Height) \ 2)
-                                        End Sub
+        AddHandler _panelHeader.Layout, AddressOf PanelHeaderLayout
 
         _flowCards.Dock = DockStyle.Fill
         _flowCards.AutoSize = True
@@ -176,6 +172,12 @@ Public Class frmResumenCantidades
         AddHandler _btnActualizar.Click, Async Sub(sender, args) Await ActualizarDatosAsync()
 
         ResumeLayout(False)
+    End Sub
+
+    Private Sub PanelHeaderLayout(sender As Object, e As LayoutEventArgs)
+        _dtpFecha.Location = New Point(0, (_panelHeader.Height - _dtpFecha.Height) \ 2)
+        _btnActualizar.Location = New Point(_dtpFecha.Right + 16, (_panelHeader.Height - _btnActualizar.Height) \ 2)
+        _lblUltimaActualizacion.Location = New Point(_panelHeader.Width - _lblUltimaActualizacion.Width, (_panelHeader.Height - _lblUltimaActualizacion.Height) \ 2)
     End Sub
 
     Private Async Sub frmResumenCantidades_Load(sender As Object, e As EventArgs) Handles MyBase.Load


### PR DESCRIPTION
## Summary
- replace the inline Layout event lambda with a named handler so the Windows Forms designer can parse the form

## Testing
- dotnet build Apex/Apex.vbproj *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e120c8e2788326a853811d17e2cb15