### PR TITLE
Fix designer helper methods scope

### DIFF
--- a/Apex/UI/frmResumenCantidades.vb
+++ b/Apex/UI/frmResumenCantidades.vb
@@ -394,7 +394,7 @@ Public Class frmResumenCantidades
         Return resultado
     End Function
 
-    Private Shared Function CrearEtiquetaValor() As Label
+    Private Function CrearEtiquetaValor() As Label
         Return New Label() With {
             .AutoSize = False,
             .Font = New Font("Segoe UI", 22.0F, FontStyle.Bold),
@@ -435,7 +435,7 @@ Public Class frmResumenCantidades
         Return panel
     End Function
 
-    Private Shared Sub ConfigurarDataGridView(grid As DataGridView)
+    Private Sub ConfigurarDataGridView(grid As DataGridView)
         With grid
             .Dock = DockStyle.Fill
             .ReadOnly = True


### PR DESCRIPTION
## Summary
- change the helper factory methods on frmResumenCantidades to be instance-level
- allow the Windows Forms designer to resolve CrearEtiquetaValor and ConfigurarDataGridView

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e123f6731c832690a2e68f36f4011c