### PR TITLE
Separar licencias generales y médicas en el resumen de cantidades

### DIFF
--- a/Apex/UI/frmResumenCantidades.Designer.vb
+++ b/Apex/UI/frmResumenCantidades.Designer.vb
@@ -41,6 +41,7 @@ Partial Class frmResumenCantidades
         Me._lblPresentes = New System.Windows.Forms.Label()
         Me._lblFrancos = New System.Windows.Forms.Label()
         Me._lblLicencias = New System.Windows.Forms.Label()
+        Me._lblLicenciasMedicas = New System.Windows.Forms.Label()
         Me._lblAusentes = New System.Windows.Forms.Label()
         Me._layoutRoot.SuspendLayout()
         Me._panelHeader.SuspendLayout()
@@ -275,6 +276,17 @@ Partial Class frmResumenCantidades
         Me._lblLicencias.Text = "0"
         Me._lblLicencias.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         '
+        '_lblLicenciasMedicas
+        '
+        Me._lblLicenciasMedicas.AutoSize = False
+        Me._lblLicenciasMedicas.Dock = System.Windows.Forms.DockStyle.Fill
+        Me._lblLicenciasMedicas.Font = New System.Drawing.Font("Segoe UI", 22.0!, System.Drawing.FontStyle.Bold)
+        Me._lblLicenciasMedicas.ForeColor = System.Drawing.Color.FromArgb(28, 41, 56)
+        Me._lblLicenciasMedicas.MinimumSize = New System.Drawing.Size(0, 60)
+        Me._lblLicenciasMedicas.Name = "_lblLicenciasMedicas"
+        Me._lblLicenciasMedicas.Text = "0"
+        Me._lblLicenciasMedicas.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
+        '
         '_lblAusentes
         '
         Me._lblAusentes.AutoSize = False
@@ -329,5 +341,6 @@ Partial Class frmResumenCantidades
     Friend WithEvents _lblPresentes As Label
     Friend WithEvents _lblFrancos As Label
     Friend WithEvents _lblLicencias As Label
+    Friend WithEvents _lblLicenciasMedicas As Label
     Friend WithEvents _lblAusentes As Label
 End Class

--- a/Apex/UI/frmResumenCantidades.vb
+++ b/Apex/UI/frmResumenCantidades.vb
@@ -44,8 +44,9 @@ Public Class frmResumenCantidades
         _flowCards.Controls.Add(CrearCard("Funcionarios inactivos", _lblInactivos, "Funcionarios marcados como inactivos."))
         _flowCards.Controls.Add(CrearCard("Presentes", _lblPresentes, "Funcionarios activos clasificados como presentes según la presencia del día."))
         _flowCards.Controls.Add(CrearCard("Francos", _lblFrancos, "Funcionarios activos asignados como franco en la fecha seleccionada."))
-        _flowCards.Controls.Add(CrearCard("Licencias vigentes", _lblLicencias, "Funcionarios activos con alguna licencia activa en la fecha."))
-        _flowCards.Controls.Add(CrearCard("Ausentes sin clasificar", _lblAusentes, "Funcionarios activos que no figuran como presentes, francos ni con licencias."))
+        _flowCards.Controls.Add(CrearCard("Licencias vigentes", _lblLicencias, "Funcionarios activos con licencias vigentes de categoría General (excluye francos y salud)."))
+        _flowCards.Controls.Add(CrearCard("Licencias médicas", _lblLicenciasMedicas, "Funcionarios activos con licencias médicas vigentes (categoría Salud)."))
+        _flowCards.Controls.Add(CrearCard("Ausentes sin clasificar", _lblAusentes, "Funcionarios activos que no figuran como presentes, francos ni con licencias generales o médicas."))
     End Sub
 
     Private Sub ConfigurarDataGridViews()
@@ -88,32 +89,41 @@ Public Class frmResumenCantidades
         _lblPresentes.Text = FormatearNumero(resumen.Presentes)
         _lblFrancos.Text = FormatearNumero(resumen.Francos)
         _lblLicencias.Text = FormatearNumero(resumen.LicenciasTotales)
+        _lblLicenciasMedicas.Text = FormatearNumero(resumen.LicenciasMedicasTotales)
         _lblAusentes.Text = FormatearNumero(resumen.Ausentes)
         _toolTip.SetToolTip(_lblAusentes, $"Funcionarios activos sin una clasificación de presencia conocida ({resumen.Ausentes} en total).")
     End Sub
 
     Private Sub ActualizarDetalleLicencias(resumen As ResumenDatos)
-        Dim licencias = resumen.LicenciasPorTipo.OrderByDescending(Function(p) p.Value).ThenBy(Function(p) p.Key, StringComparer.OrdinalIgnoreCase).ToList()
-        Dim hayDatos = licencias.Any()
+        Dim licenciasGenerales = resumen.LicenciasPorTipo.OrderByDescending(Function(p) p.Value).ThenBy(Function(p) p.Key, StringComparer.OrdinalIgnoreCase).ToList()
+        Dim licenciasMedicas = resumen.LicenciasMedicasPorTipo.OrderByDescending(Function(p) p.Value).ThenBy(Function(p) p.Key, StringComparer.OrdinalIgnoreCase).ToList()
+        Dim hayDatos = licenciasGenerales.Any() OrElse licenciasMedicas.Any()
 
         _lblLicenciasSinDatos.Visible = Not hayDatos
         _dgvLicencias.Visible = hayDatos
 
         If hayDatos Then
             Dim tabla = New DataTable()
+            tabla.Columns.Add("Clasificación", GetType(String))
             tabla.Columns.Add("Tipo", GetType(String))
             tabla.Columns.Add("Cantidad", GetType(Integer))
-            For Each item In licencias
-                tabla.Rows.Add(item.Key, item.Value)
+
+            For Each item In licenciasGenerales
+                tabla.Rows.Add("Licencias vigentes", item.Key, item.Value)
             Next
+
+            For Each item In licenciasMedicas
+                tabla.Rows.Add("Licencias médicas", item.Key, item.Value)
+            Next
+
             _dgvLicencias.DataSource = tabla
 
-            ' --- AÑADIR ESTAS LÍNEAS AQUÍ ---
-            _dgvLicencias.Columns(0).HeaderText = "Tipo de licencia"
-            _dgvLicencias.Columns(1).HeaderText = "Cantidad"
-            _dgvLicencias.Columns(0).AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
-            _dgvLicencias.Columns(1).AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells
-            ' -----------------------------------
+            _dgvLicencias.Columns(0).HeaderText = "Clasificación"
+            _dgvLicencias.Columns(1).HeaderText = "Tipo de licencia"
+            _dgvLicencias.Columns(2).HeaderText = "Cantidad"
+            _dgvLicencias.Columns(0).AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells
+            _dgvLicencias.Columns(1).AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
+            _dgvLicencias.Columns(2).AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells
         Else
             _dgvLicencias.DataSource = Nothing
         End If
@@ -150,6 +160,7 @@ Public Class frmResumenCantidades
         Dim resumen = New ResumenDatos() With {
             .FechaConsulta = fecha,
             .LicenciasPorTipo = New Dictionary(Of String, Integer)(StringComparer.OrdinalIgnoreCase),
+            .LicenciasMedicasPorTipo = New Dictionary(Of String, Integer)(StringComparer.OrdinalIgnoreCase),
             .PresenciasPorEstado = New Dictionary(Of String, Integer)(StringComparer.OrdinalIgnoreCase)
         }
 
@@ -182,33 +193,51 @@ Public Class frmResumenCantidades
             Next
         End Using
 
-        Dim licenciasPorTipo = Await ObtenerLicenciasPorTipoAsync(fecha)
-        If licenciasPorTipo.Any() Then
-            resumen.LicenciasPorTipo = licenciasPorTipo
-            resumen.LicenciasTotales = licenciasPorTipo.Values.Sum()
+        Dim licenciasClasificadas = Await ObtenerLicenciasClasificadasAsync(fecha)
+        If licenciasClasificadas.LicenciasGenerales.Any() Then
+            resumen.LicenciasPorTipo = licenciasClasificadas.LicenciasGenerales
+            resumen.LicenciasTotales = licenciasClasificadas.LicenciasGenerales.Values.Sum()
         End If
 
-        resumen.Ausentes = Math.Max(0, resumen.Activos - resumen.Presentes - resumen.Francos - resumen.LicenciasTotales)
+        If licenciasClasificadas.LicenciasMedicas.Any() Then
+            resumen.LicenciasMedicasPorTipo = licenciasClasificadas.LicenciasMedicas
+            resumen.LicenciasMedicasTotales = licenciasClasificadas.LicenciasMedicas.Values.Sum()
+        End If
+
+        resumen.Ausentes = Math.Max(0, resumen.Activos - resumen.Presentes - resumen.Francos - resumen.LicenciasTotales - resumen.LicenciasMedicasTotales)
 
         Return resumen
     End Function
 
-    Private Shared Async Function ObtenerLicenciasPorTipoAsync(fecha As Date) As Task(Of Dictionary(Of String, Integer))
-        Dim resultado = New Dictionary(Of String, Integer)(StringComparer.OrdinalIgnoreCase)
+    Private Shared Async Function ObtenerLicenciasClasificadasAsync(fecha As Date) As Task(Of LicenciasClasificadas)
+        Dim resultado = New LicenciasClasificadas()
         Dim tabla = Await ConsultasGenericas.ObtenerDatosGenericosAsync(TipoOrigenDatos.Licencias, fecha, fecha)
         If tabla Is Nothing OrElse tabla.Rows.Count = 0 Then Return resultado
 
         Dim columnaDisponible = {"TipoLicencia", "Tipo", "Licencia"}.FirstOrDefault(Function(c) tabla.Columns.Contains(c))
         If String.IsNullOrEmpty(columnaDisponible) Then Return resultado
 
+        Dim tieneCategoria = tabla.Columns.Contains("CategoriaAusenciaId")
+        Dim tieneActivo = tabla.Columns.Contains("Activo")
+
         For Each row As DataRow In tabla.Rows
+            If tieneActivo AndAlso Not Convert.ToBoolean(row("Activo")) Then Continue For
+
+            Dim categoriaId As Integer? = Nothing
+            If tieneCategoria AndAlso Not Convert.IsDBNull(row("CategoriaAusenciaId")) Then
+                categoriaId = Convert.ToInt32(row("CategoriaAusenciaId"))
+            End If
+
             Dim tipo = Convert.ToString(row(columnaDisponible)).Trim()
             If String.IsNullOrEmpty(tipo) Then tipo = "Sin especificar"
 
-            If resultado.ContainsKey(tipo) Then
-                resultado(tipo) += 1
-            Else
-                resultado(tipo) = 1
+            Dim tipoNormalizado = ModConstantesApex.Normalizar(tipo)
+
+            If categoriaId.HasValue AndAlso categoriaId.Value = ModConstantesApex.CategoriaAusenciaId.Salud Then
+                AgregarONuevo(resultado.LicenciasMedicas, tipo, 1)
+            ElseIf categoriaId.HasValue AndAlso categoriaId.Value = ModConstantesApex.CategoriaAusenciaId.General Then
+                If tipoNormalizado.Contains("franco") Then Continue For
+                AgregarONuevo(resultado.LicenciasGenerales, tipo, 1)
             End If
         Next
 
@@ -280,6 +309,14 @@ Public Class frmResumenCantidades
         Return valor.ToString("N0", CultureInfo.CurrentCulture)
     End Function
 
+    Private Shared Sub AgregarONuevo(diccionario As Dictionary(Of String, Integer), clave As String, incremento As Integer)
+        If diccionario.ContainsKey(clave) Then
+            diccionario(clave) += incremento
+        Else
+            diccionario(clave) = incremento
+        End If
+    End Sub
+
     Private Class ResumenDatos
         Public Property FechaConsulta As Date
         Public Property TotalFuncionarios As Integer
@@ -288,9 +325,21 @@ Public Class frmResumenCantidades
         Public Property Presentes As Integer
         Public Property Francos As Integer
         Public Property LicenciasTotales As Integer
+        Public Property LicenciasMedicasTotales As Integer
         Public Property Ausentes As Integer
         Public Property LicenciasPorTipo As Dictionary(Of String, Integer)
+        Public Property LicenciasMedicasPorTipo As Dictionary(Of String, Integer)
         Public Property PresenciasPorEstado As Dictionary(Of String, Integer)
+    End Class
+
+    Private Class LicenciasClasificadas
+        Public Sub New()
+            LicenciasGenerales = New Dictionary(Of String, Integer)(StringComparer.OrdinalIgnoreCase)
+            LicenciasMedicas = New Dictionary(Of String, Integer)(StringComparer.OrdinalIgnoreCase)
+        End Sub
+
+        Public Property LicenciasGenerales As Dictionary(Of String, Integer)
+        Public Property LicenciasMedicas As Dictionary(Of String, Integer)
     End Class
 
     Private Enum CategoriaPresencia


### PR DESCRIPTION
## Summary
- clasifiqué las licencias vigentes en generales y médicas utilizando las categorías de ModConstantesApex
- ajusté el resumen de cantidades para mostrar tarjetas y detalles separados para licencias generales y médicas
- expuse metadatos de categoría de licencia en la consulta genérica de licencias para reutilizarlos en los reportes

## Testing
- dotnet build (not run, command not available en el entorno)


------
https://chatgpt.com/codex/tasks/task_e_68e168a5014483269b70eb9c3450070a