### PR TITLE
Ajustar resumen de cantidades por categorías

### DIFF
--- a/Apex/UI/frmResumenCantidades.Designer.vb
+++ b/Apex/UI/frmResumenCantidades.Designer.vb
@@ -188,7 +188,7 @@ Partial Class frmResumenCantidades
         Me._groupPresencias.Size = New System.Drawing.Size(525, 614)
         Me._groupPresencias.TabIndex = 1
         Me._groupPresencias.TabStop = False
-        Me._groupPresencias.Text = "Presencias por estado"
+        Me._groupPresencias.Text = "Presencias por categoría"
         '
         '_lblPresenciasSinDatos
         '
@@ -199,7 +199,7 @@ Partial Class frmResumenCantidades
         Me._lblPresenciasSinDatos.Name = "_lblPresenciasSinDatos"
         Me._lblPresenciasSinDatos.Size = New System.Drawing.Size(501, 574)
         Me._lblPresenciasSinDatos.TabIndex = 1
-        Me._lblPresenciasSinDatos.Text = "No se registran datos de presencia para la fecha seleccionada."
+        Me._lblPresenciasSinDatos.Text = "No se registran datos de presencias por categoría para la fecha seleccionada."
         Me._lblPresenciasSinDatos.TextAlign = System.Drawing.ContentAlignment.MiddleCenter
         Me._lblPresenciasSinDatos.Visible = False
         '


### PR DESCRIPTION
## Summary
- Ocultar la tarjeta de funcionarios inactivos y recalcar los totales sobre la dotación activa.
- Reemplazar la grilla de presencias por estado con un resumen por categoría de ausencia basado en ModConstantesApex y sólo con funcionarios activos.

## Testing
- No se ejecutaron pruebas automatizadas (herramienta `dotnet` no disponible en el entorno).

------
https://chatgpt.com/codex/tasks/task_e_68e16c8393d483268c52c45e4b7b4c32