### PR TITLE
Fix activosSet scope in resumen quantities form

### DIFF
--- a/Apex/UI/frmResumenCantidades.vb
+++ b/Apex/UI/frmResumenCantidades.vb
@@ -186,13 +186,14 @@ Public Class frmResumenCantidades
 
         Dim presentesSet = New HashSet(Of Integer)()
         Dim francosSet = New HashSet(Of Integer)()
+        Dim activosSet As HashSet(Of Integer)
 
         Using uow As New UnitOfWork()
             Dim ctx = uow.Context
             resumen.TotalFuncionarios = Await ctx.Set(Of Funcionario)().CountAsync()
 
             Dim activosIds = Await ctx.Set(Of Funcionario)().Where(Function(f) f.Activo).Select(Function(f) f.Id).ToListAsync()
-            Dim activosSet = New HashSet(Of Integer)(activosIds)
+            activosSet = New HashSet(Of Integer)(activosIds)
             resumen.Activos = activosSet.Count
             resumen.Inactivos = resumen.TotalFuncionarios - resumen.Activos
 


### PR DESCRIPTION
## Summary
- declare the activosSet hash set at the method scope so it can be reused after closing the data context

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1725601f08326ac7c790fd02e785a