### PR TITLE
Fix missing FuncionarioId in generic license data

### DIFF
--- a/Apex/Helpers/ConsultasGenericas.vb
+++ b/Apex/Helpers/ConsultasGenericas.vb
@@ -242,6 +242,7 @@ Public Module ConsultasGenericas
                                                              End If
 
                                                              Return New With {
+                                                                 .FuncionarioId = lic.FuncionarioId,
                                                                  .NombreCompleto = NormalizarValorReporte(lic.NombreFuncionario, "N/A"),
                                                                  .Cedula = NormalizarValorReporte(lic.CI, "N/A"),
                                                                  .TipoLicenciaId = lic.TipoLicenciaId,


### PR DESCRIPTION
## Summary
- include the FuncionarioId in the generic license dataset so license holders are recognized during classification

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1786107108326851622ce02fd6123